### PR TITLE
Issue #22: Convert-WindowsImage does not work with numeric editions.

### DIFF
--- a/hyperv-tools/Convert-WindowsImage/Convert-WindowsImage.ps1
+++ b/hyperv-tools/Convert-WindowsImage/Convert-WindowsImage.ps1
@@ -4087,9 +4087,10 @@ namespace WIM2VHD {
                 $Edition | ForEach-Object -Process {
 
                     $Edition = $PSItem
-    
-                    if ([Int32]::TryParse($Edition, [ref]$null)) {
-                        $openImage = $openWim[[Int32]$Edition]    
+
+                    $editionNumber = $null;
+                    if ([Int32]::TryParse($Edition, [ref]$editionNumber)) {
+                        $openImage = $openWim[[Int32]$editionNumber]
                     } else {
                         $openImage = $openWim[$Edition]
                     }    


### PR DESCRIPTION
Forgive me for just jumping in; I hope it's alright ... I have successfully used this change locally a few times and previously spoken to Artem about using this fix. We're not entirely sure what changed to require being more selective with the parse specifier.