### PR TITLE
Fix bug in runDockerDaemon.cmd

### DIFF
--- a/windows-server-container-tools/Install-ContainerHost/Install-ContainerHost.ps1
+++ b/windows-server-container-tools/Install-ContainerHost/Install-ContainerHost.ps1
@@ -608,12 +608,11 @@ Test-Admin()
 $runDockerDaemon = @"
 
 @echo off
- 
+set certs=%ProgramData%\docker\certs.d 
+
 if exist %ProgramData%\docker (goto :run)
 mkdir %ProgramData%\docker
 
-set certs=%ProgramData%\docker\certs.d
- 
 :run
 if exist %certs%\server-cert.pem (goto :secure)
  


### PR DESCRIPTION
Without this fix, certs variable isn't set before it is used