### PR TITLE
Cleaned up non-domain access and added references

### DIFF
--- a/virtualization/hyperv_on_windows/user_guide/remote_host_management.md
+++ b/virtualization/hyperv_on_windows/user_guide/remote_host_management.md
@@ -85,25 +85,13 @@ To connect using IP address, enter the IP address into the **Another Computer** 
 ## Manage a Hyper-V host outside your domain (or with no domain) ##
 > This is only available when connecting to a Windows 10 or Server 2016 Technical Preview 3 or later remote host
 
-<!--Assuming this isn't done yet...again needs context.-->
-Local Hyper-V Host:
-1.	Enable-PSRemoting
-Came back with netowork set to public.
-Ran
-Set-NetConnectionProfile -Name "name" -NetworkCategory private
-2. Set-Item WSMan:\localhost\Client\TrustedHosts * -Force
-3. Enable-WSManCredSSP -Role client -DelegateComputer *
+On the Hyper-V Host to be managed, run the following as an administrator:
 
-For workgroup only:
-1. (should be done) Computer Policy\Administrative Templates\System\Credentials Delegation\Allow Delegating Fresh Credentials → Set to enabled and add WSMAN/* ].  To list of computers, check the box forConcatenate OS defaults with input above
-
-2. Computer Policy\Administrative Templates\System\Credentials Delegation\Allow Delegating Fresh Credentials with NTLM-only server authentication → Set to enabled and add WSMAN/* to list of computers, check the box for Concatenate OS defaults with input above
-3. Computer Policy\Administrative Templates\Windows Components\Windows Remote Management (WinRM)\WinRM Client\Allow CredSSP authentication → Set to enabled
-
-Remote Hyper-V Host:
-1. Disabled the firewall :)
-2. Enable-PSRemoting
-3. Set-Item WSMan:\localhost\Client\TrustedHosts * -Force
-So that's the demo-only instructions I used.  Replace * and turn off firewall with a single computer and letting credssp and winRM through
-
-
+1.	[Enable-PSRemoting](https://technet.microsoft.com/en-us/library/hh849694.aspx)
+  * [Enable-PSRemoting](https://technet.microsoft.com/en-us/library/hh849694.aspx) will create the necessary firewall rules for *private* network zones. To allow this access on public zones you will need to enable the rules for CredSSP and WinRM.
+2. Set-Item WSMan:\localhost\Client\TrustedHosts -value "fqdn-of-managing-pc"
+  * Alternately, you can allow all hosts to be trusted to manage via:
+  * Set-Item WSMan:\localhost\Client\TrustedHosts -value * -force
+3. [Enable-WSManCredSSP](https://technet.microsoft.com/en-us/library/hh849872.aspx) -Role client -DelegateComputer "fqdn-of-managing-pc"
+  * Alternately, you can allow all hosts to be trusted to manage via:
+  * [Enable-WSManCredSSP](https://technet.microsoft.com/en-us/library/hh849872.aspx) -Role client -DelegateComputer *


### PR DESCRIPTION
Removed "Workgroup Only" only section and "Remove Hyper-V Host"
These two instruction sets accomplished the same thing as "Local Hyper-V host", just using different methods (GPO vs POSH), and advocated unnecessary things (disabling firewall). Added alternate commands to only only specific machines (more secure by default), but left the generic allow all instructions in place. Also corrected some readability issues.