### PR TITLE
Fix container download

### DIFF
--- a/windows-server-container-tools/Install-ContainerHost/Install-ContainerHost.ps1
+++ b/windows-server-container-tools/Install-ContainerHost/Install-ContainerHost.ps1
@@ -444,7 +444,7 @@ Install-ContainerHost
                 
                 $hostBuildInfo = (gp "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion").BuildLabEx.Split(".")
                 $version = $hostBuildInfo[0]
-                $qfe = $hostBuildInfo[1]
+                $qfe = 0
                 $imageVersion = "10.0.$version.$qfe"
 
                 Write-Output "Getting Container OS image ($imageName) version $imageVersion from OneGet (this may take a few minutes)..."


### PR DESCRIPTION
I tried to install docker, but an error occured while downloading the container image from OneGet.

```
PS C:\Windows\system32> C:\Install-ContainerHost.ps1 -HyperV
Querying status of Windows feature: Containers...
Feature Containers is already enabled.
Querying status of Windows feature: Hyper-V...
Feature Hyper-V is already enabled.
Waiting for Hyper-V Management...
Networking is already configured.  Confirming configuration...
Getting Container OS image (WindowsServerCore) version 10.0.10586.11 from OneGet (this may take a few minutes)...
Install-ContainerImage : Unable to download.
At C:\Install-ContainerHost.ps1:451 char:17
+ ...              Install-ContainerImage $imageName -Version $imageVersion
+                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,Install-ContainerImage

Container base image install complete.  Querying container images...
Waiting for VMMS to return image at (11/20/2015 00:20:32)...
Waiting for VMMS to return image at (11/20/2015 00:20:34)...
```

So I fixed the Install-ContainerHost.ps1 as @taylorb-microsoft did in his PR #88.

 Now it downloads the image.
