### PR TITLE
Fix dashes in code examples

### DIFF
--- a/demos/2015-BigBuild/BigBuild.ps1
+++ b/demos/2015-BigBuild/BigBuild.ps1
@@ -267,7 +267,7 @@ CreateVM $vmName $GuestOSName $IPNumber
       icm -VMName $VMName -Credential $localCred {
          param($VMName, $domainName, $domainAdminPassword)
          Write-Output "[$($VMName)]:: Installing AD"
-         Install-WindowsFeature AD-Domain-Services –IncludeManagementTools | out-null
+         Install-WindowsFeature AD-Domain-Services -IncludeManagementTools | out-null
          Write-Output "[$($VMName)]:: Enabling Active Directory and promoting to domain controller"
          Install-ADDSForest -DomainName $domainName -InstallDNS -NoDNSonNetwork -NoRebootOnCompletion `
                             -SafeModeAdministratorPassword (ConvertTo-SecureString $domainAdminPassword -AsPlainText -Force) -confirm:$false
@@ -300,7 +300,7 @@ CreateVM $vmName $GuestOSName $IPNumber
       icm -VMName $VMName -Credential $localCred {
          param($VMName, $domainCred, $domainName)
          Write-Output "[$($VMName)]:: Installing DHCP"
-         Install-WindowsFeature DHCP –IncludeManagementTools | out-null
+         Install-WindowsFeature DHCP -IncludeManagementTools | out-null
          Write-Output "[$($VMName)]:: Joining domain as `"$($env:computername)`""
          while (!(Test-Connection -Computername $domainName -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) {sleep -seconds 1}
          do {Add-Computer -DomainName $domainName -Credential $domainCred -ea SilentlyContinue} until ($?)
@@ -341,7 +341,7 @@ CreateVM $vmName $GuestOSName $IPNumber
       icm -VMName $VMName -Credential $localCred {
          param($VMName, $domainCred, $domainName)
          Write-Output "[$($VMName)]:: Installing AD"
-         Install-WindowsFeature AD-Domain-Services –IncludeManagementTools | out-null
+         Install-WindowsFeature AD-Domain-Services -IncludeManagementTools | out-null
          Write-Output "[$($VMName)]:: Joining domain as `"$($env:computername)`""
          while (!(Test-Connection -Computername $domainName -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) {sleep -seconds 1}
          do {Add-Computer -DomainName $domainName -Credential $domainCred -ea SilentlyContinue} until ($?)
@@ -420,7 +420,7 @@ CreateVM $vmName $GuestOSName
       icm -VMName $VMName -Credential $localCred {
          param($VMName, $domainCred, $domainName)
          Write-Output "[$($VMName)]:: Installing Clustering"
-         Install-WindowsFeature –Name File-Services, Failover-Clustering –IncludeManagementTools | out-null
+         Install-WindowsFeature -Name File-Services, Failover-Clustering -IncludeManagementTools | out-null
          Write-Output "[$($VMName)]:: Joining domain as `"$($env:computername)`""
          while (!(Test-Connection -Computername $domainName -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) {sleep -seconds 1}
          do {Add-Computer -DomainName $domainName -Credential $domainCred -ea SilentlyContinue} until ($?)
@@ -440,7 +440,7 @@ waitForPSDirect "Storage Node 4" -cred $domainCred
 
 icm -VMName "Management Console" -Credential $domainCred {
 param ($domainName)
-do {New-Cluster –Name S2DCluster –Node S2DNode1,S2DNode2,S2DNode3,S2DNode4 –NoStorage} until ($?)
+do {New-Cluster -Name S2DCluster -Node S2DNode1,S2DNode2,S2DNode3,S2DNode4 -NoStorage} until ($?)
 while (!(Test-Connection -Computername "S2DCluster.$($domainName)" -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) 
       {ipconfig /flushdns; sleep -seconds 1}
 Enable-ClusterStorageSpacesDirect -Cluster "S2DCluster.$($domainName)"
@@ -450,20 +450,20 @@ Add-ClusterScaleoutFileServerRole -name S2DFileServer -cluster "S2DCluster.$($do
 icm -VMName "Storage Node 1" -Credential $domainCred {
 param ($domainName)
 New-StoragePool -StorageSubSystemName "S2DCluster.$($domainName)" -FriendlyName S2DPool -WriteCacheSizeDefault 0 -ProvisioningTypeDefault Fixed -ResiliencySettingNameDefault Mirror -PhysicalDisk (Get-StorageSubSystem  -Name "S2DCluster.$($domainName)" | Get-PhysicalDisk)
-New-Volume -StoragePoolFriendlyName S2DPool -FriendlyName S2DDisk -PhysicalDiskRedundancy 2 -FileSystem CSVFS_REFS –Size 500GB
-Set-FileIntegrity "C:\ClusterStorage\Volume1" –Enable $false
+New-Volume -StoragePoolFriendlyName S2DPool -FriendlyName S2DDisk -PhysicalDiskRedundancy 2 -FileSystem CSVFS_REFS -Size 500GB
+Set-FileIntegrity "C:\ClusterStorage\Volume1" -Enable $false
 
          MD C:\ClusterStorage\Volume1\VHDX
          New-SmbShare -Name VHDX -Path C:\ClusterStorage\Volume1\VHDX -FullAccess "$($domainName)\administrator", "$($domainName)\Benjamin", "$($domainName)\Management$"
-         Set-SmbPathAcl –ShareName VHDX
+         Set-SmbPathAcl -ShareName VHDX
 
          MD C:\ClusterStorage\Volume1\ClusQuorum
          New-SmbShare -Name ClusQuorum -Path C:\ClusterStorage\Volume1\ClusQuorum -FullAccess "$($domainName)\administrator", "$($domainName)\Benjamin", "$($domainName)\Management$"
-         Set-SmbPathAcl –ShareName ClusQuorum
+         Set-SmbPathAcl -ShareName ClusQuorum
 
          MD C:\ClusterStorage\Volume1\ClusData
          New-SmbShare -Name ClusData -Path C:\ClusterStorage\Volume1\ClusData -FullAccess "$($domainName)\administrator", "$($domainName)\Benjamin", "$($domainName)\Management$"
-         Set-SmbPathAcl –ShareName ClusData
+         Set-SmbPathAcl -ShareName ClusData
 
 } -ArgumentList $domainName
 
@@ -477,7 +477,7 @@ icm -VMName $VMName -Credential $localCred {
         stop-container "IIS"
         New-ContainerImage -ContainerName "IIS" -Name "IIS" -Publisher "Armstrong" -Version 1.0
         Remove-Container -Name "IIS" -Force
-        New-NetFirewallRule -DisplayName "Allow inbound TCP Port 80" -Direction inbound –LocalPort 80 -Protocol TCP -Action Allow}
+        New-NetFirewallRule -DisplayName "Allow inbound TCP Port 80" -Direction inbound -LocalPort 80 -Protocol TCP -Action Allow}
 icm -VMName $VMName -Credential $localCred {& cmd /c "C:\windows\system32\Sysprep\sysprep.exe /quiet /generalize /oobe /shutdown /unattend:C:\unattend.xml"}
 
 logger $VMName "Ready to inject Container Host into Storage Cluster"
@@ -558,7 +558,7 @@ waitForPSDirect "Hyper-V Node 8" -cred $domainCred
 
 icm -VMName "Management Console" -Credential $domainCred {
 param ($domainName)
-do {New-Cluster –Name HVCluster –Node HVNode1,HVNode2,HVNode3,HVNode4,HVNode5,HVNode6,HVNode7,HVNode8 –NoStorage} until ($?)
+do {New-Cluster -Name HVCluster -Node HVNode1,HVNode2,HVNode3,HVNode4,HVNode5,HVNode6,HVNode7,HVNode8 -NoStorage} until ($?)
 while (!(Test-Connection -Computername "S2DCluster.$($domainName)" -BufferSize 16 -Count 1 -Quiet -ea SilentlyContinue)) 
       {ipconfig /flushdns; sleep -seconds 1}
 } -ArgumentList $domainName
@@ -580,9 +580,9 @@ get-SmbShareAccess ClusData | Grant-SmbShareAccess -AccountName "$($domainName)\
                                              "$($domainName)\HVNode7$","$($domainName)\HVNode8$","$($domainName)\HVCluster$" `
                                              -AccessRight full -Confirm:$false
 
-Set-SmbPathAcl –ShareName VHDX
-Set-SmbPathAcl –ShareName ClusQuorum
-Set-SmbPathAcl –ShareName ClusData
+Set-SmbPathAcl -ShareName VHDX
+Set-SmbPathAcl -ShareName ClusQuorum
+Set-SmbPathAcl -ShareName ClusData
 } -ArgumentList $domainName
 
 icm -VMName "Management Console" -Credential $domainCred {

--- a/demos/2015-Ignite-Whats-New/scripts/Convert-WindowsImage.ps1
+++ b/demos/2015-Ignite-Whats-New/scripts/Convert-WindowsImage.ps1
@@ -2346,7 +2346,7 @@ namespace WIM2VHD {
         }
 
         /// <summary>
-        /// Creates a fixed-size Virtual Hard Disk. Supports both sync and async modes. This methods always calls the V2 version of the 
+        /// Creates a fixed-Size Virtual Hard Disk. Supports both sync and async modes. This methods always calls the V2 version of the 
         /// CreateVirtualDisk API, and creates VHD2. 
         /// </summary>
         /// <param name="path">The path and name of the VHD to create.</param>

--- a/demos/2015-Ignite-Whats-New/scripts/Demo.ps1
+++ b/demos/2015-Ignite-Whats-New/scripts/Demo.ps1
@@ -527,7 +527,7 @@ write-host "VHDX operations on NTFS"
 write-host
 write-host "Press enter to create a 1GB fixed VHDX on an NTFS partition"
 read-host
-$time = (measure-command {icm -ComputerName demo-laptop-2 -Credential $domainCred -Authentication Credssp {new-vhd -path F:\1GB.vhdx -size 1GB -fixed | out-null}}).totalseconds
+$time = (measure-command {icm -ComputerName demo-laptop-2 -Credential $domainCred -Authentication Credssp {new-vhd -path F:\1GB.vhdx -Size 1GB -fixed | out-null}}).totalseconds
 Write-host
 Write-host "Total time for creation of 1GB fixed VHDX: $($time) seconds"
 icm -ComputerName demo-laptop-2 -Credential $domainCred -Authentication Credssp {del f:\1GB.VHDX}
@@ -536,14 +536,14 @@ write-host "VHDX operations on REFS"
 write-host
 write-host "Press enter to create a 1GB fixed VHDX on an REFS partition"
 read-host
-$time = (measure-command {icm -ComputerName demo-laptop-2 -Credential $domainCred -Authentication Credssp {new-vhd -path G:\1GB.vhdx -size 1GB -fixed | out-null}}).totalseconds
+$time = (measure-command {icm -ComputerName demo-laptop-2 -Credential $domainCred -Authentication Credssp {new-vhd -path G:\1GB.vhdx -Size 1GB -fixed | out-null}}).totalseconds
 Write-host
 Write-host "Total time for creation of 1GB fixed VHDX: $($time) seconds"
 icm -ComputerName demo-laptop-2 -Credential $domainCred -Authentication Credssp {del G:\1GB.VHDX}
 write-host
 write-host "Press enter to create a 50GB fixed VHDX on an REFS partition"
 read-host
-$time = (measure-command {icm -ComputerName demo-laptop-2 -Credential $domainCred -Authentication Credssp {new-vhd -path G:\50GB.vhdx -size 50GB -fixed | out-null}}).totalseconds
+$time = (measure-command {icm -ComputerName demo-laptop-2 -Credential $domainCred -Authentication Credssp {new-vhd -path G:\50GB.vhdx -Size 50GB -fixed | out-null}}).totalseconds
 Write-host
 Write-host "Total time for creation of 50GB fixed VHDX: $($time) seconds"
 icm -ComputerName demo-laptop-2 -Credential $domainCred -Authentication Credssp {del G:\50GB.VHDX}

--- a/demos/2015-Ignite-Whats-New/scripts/WorkloadSetup.ps1
+++ b/demos/2015-Ignite-Whats-New/scripts/WorkloadSetup.ps1
@@ -69,14 +69,14 @@ function CreateBaseVM([string]$VMName, `
          dism.exe /Online /Enable-Feature:Microsoft-Hyper-V /All /NoRestart | out-null}
       if ($enableClustering) {
          Write-Output "[$($VMName)]:: Enabling Clustering"
-         Install-WindowsFeature Failover-Clustering –IncludeManagementTools | out-null}
+         Install-WindowsFeature Failover-Clustering -IncludeManagementTools | out-null}
       if ($DomainController) {
          Write-Output "[$($VMName)]:: Enabling iSCSI, AD and DHCP"
          Add-WindowsFeature -Name FS-iSCSITarget-Server | out-null
-         Install-WindowsFeature AD-Domain-Services, DHCP –IncludeManagementTools | out-null}
+         Install-WindowsFeature AD-Domain-Services, DHCP -IncludeManagementTools | out-null}
       if ($SOFSnode) {
          Write-Output "[$($VMName)]:: Enabling file services"
-         Install-WindowsFeature File-Services, FS-FileServer –IncludeManagementTools | Out-Null}
+         Install-WindowsFeature File-Services, FS-FileServer -IncludeManagementTools | Out-Null}
       Write-Output "[$($VMName)]:: Configuring WSMAN Trusted hosts"
       Set-Item WSMan:\localhost\Client\TrustedHosts "*.ignite.demo" -Force
       Set-Item WSMan:\localhost\client\trustedhosts "10.100.7.*" -force -concatenate
@@ -118,11 +118,11 @@ function CreateBaseVM([string]$VMName, `
       icm -VMName $VMName -Credential $domainCred {
          param($VMName)
          Write-Output "[$($VMName)]:: Creating VHDXs for iSCSI targets"
-         New-IscsiVirtualDisk C:\iSCSITargetDisks\Quorum.vhdx –size 10GB | Out-Null
-         New-IscsiVirtualDisk C:\iSCSITargetDisks\Data.vhdx –size 120GB | Out-Null
+         New-IscsiVirtualDisk C:\iSCSITargetDisks\Quorum.vhdx -Size 10GB | Out-Null
+         New-IscsiVirtualDisk C:\iSCSITargetDisks\Data.vhdx -Size 120GB | Out-Null
          Write-Output "[$($VMName)]:: Creating iSCSI targets"
-         New-IscsiServerTarget ISCSIQuorum –InitiatorIds "Iqn:iqn.1991-05.com.microsoft:sofs-n1.ignite.demo" | Out-Null
-         New-IscsiServerTarget ISCSIData –InitiatorIds "Iqn:iqn.1991-05.com.microsoft:sofs-n1.ignite.demo" | Out-Null
+         New-IscsiServerTarget ISCSIQuorum -InitiatorIds "Iqn:iqn.1991-05.com.microsoft:sofs-n1.ignite.demo" | Out-Null
+         New-IscsiServerTarget ISCSIData -InitiatorIds "Iqn:iqn.1991-05.com.microsoft:sofs-n1.ignite.demo" | Out-Null
          Write-Output "[$($VMName)]:: Mapping VHDX files to iSCSI targets"
          Add-IscsiVirtualDiskTargetMapping ISCSIQuorum C:\iSCSITargetDisks\Quorum.vhdx -lun 0 
          Add-IscsiVirtualDiskTargetMapping ISCSIData C:\iSCSITargetDisks\Data.vhdx -lun 0
@@ -155,7 +155,7 @@ function CreateBaseVM([string]$VMName, `
             Initialize-Disk -Number $_.Number -PartitionStyle MBR 
             New-Partition -DiskNumber $_.Number -UseMaximumSize | Set-Partition -NewDriveLetter $d  
             Initialize-Volume -DriveLetter $d -FileSystem NTFS -Confirm:$false}
-         New-Cluster –Name SOFS -Node $env:COMPUTERNAME -StaticAddress 10.100.7.3 
+         New-Cluster -Name SOFS -Node $env:COMPUTERNAME -StaticAddress 10.100.7.3 
          Get-Disk | ?{$_.BusType -eq "iSCSI"} | Add-ClusterDisk
          Get-ClusterResource | ? Name -eq "Cluster Disk 1" | %{Set-ClusterQuorum -DiskWitness $_}
          Get-ClusterResource | ? Name -eq "Cluster Disk 2" | Add-ClusterSharedVolume
@@ -163,15 +163,15 @@ function CreateBaseVM([string]$VMName, `
 
          MD C:\ClusterStorage\Volume1\VHDX
          New-SmbShare -Name VHDX -Path C:\ClusterStorage\Volume1\VHDX -FullAccess Ignite.demo\administrator
-         Set-SmbPathAcl –ShareName VHDX
+         Set-SmbPathAcl -ShareName VHDX
 
          MD C:\ClusterStorage\Volume1\ClusQuorum
          New-SmbShare -Name ClusQuorum -Path C:\ClusterStorage\Volume1\ClusQuorum -FullAccess Ignite.demo\administrator
-         Set-SmbPathAcl –ShareName ClusQuorum
+         Set-SmbPathAcl -ShareName ClusQuorum
 
          MD C:\ClusterStorage\Volume1\ClusData
          New-SmbShare -Name ClusData -Path C:\ClusterStorage\Volume1\ClusData -FullAccess Ignite.demo\administrator
-         Set-SmbPathAcl –ShareName ClusData}
+         Set-SmbPathAcl -ShareName ClusData}
          }
 
 

--- a/hyperv-samples/benarm-powershell/GuestNameCheck.ps1
+++ b/hyperv-samples/benarm-powershell/GuestNameCheck.ps1
@@ -1,5 +1,5 @@
 # Get the virtual machine name from the parent partition
- $vmName = (Get-ItemProperty –path “HKLM:\SOFTWARE\Microsoft\Virtual Machine\Guest\Parameters”).VirtualMachineName
+ $vmName = (Get-ItemProperty -path “HKLM:\SOFTWARE\Microsoft\Virtual Machine\Guest\Parameters”).VirtualMachineName
  # Replace any non-alphanumeric characters with an underscore
  $vmName = [Regex]::Replace($vmName,"\W","_")
  # Trim names that are longer than 15 characters

--- a/hyperv-tools/Nested/Get-NestedVirtStatus.ps1
+++ b/hyperv-tools/Nested/Get-NestedVirtStatus.ps1
@@ -159,7 +159,7 @@ $hvloadoptions = bcdedit /enum | Select-String "hypervisorloadoptions"
 if ($hvloadoptions) {
     $HostNested.HypervisorLoadOptionsPresent = $true
     $setting = $hvloadoptions.line.split(' ')
-    if($hvloadoptions.line –match “OFFERNESTEDVIRT=FALSE”) {
+    if($hvloadoptions.line -match “OFFERNESTEDVIRT=FALSE”) {
         $HostNested.HostNestedSupport = $false
         $HostCfgErrors += ($HostCfgErrorMsgs["BcdDisabled"])
 

--- a/hyperv-tools/ic-update/offline-update-host.ps1
+++ b/hyperv-tools/ic-update/offline-update-host.ps1
@@ -7,7 +7,7 @@ Param(
 )
 
 #Mount the VHD
-$diskNo=(Mount-VHD -Path $vhdPath –Passthru).DiskNumber
+$diskNo=(Mount-VHD -Path $vhdPath -Passthru).DiskNumber
 
 #Get the driver letter associated with the mounted VHD, note this assumes it only has one partition if there are more use the one with OS bits
 $driveLetter=(Get-Disk $diskNo | Get-Partition).DriveLetter

--- a/virtualization/hyperv_on_windows/quick_start/walkthrough_install.md
+++ b/virtualization/hyperv_on_windows/quick_start/walkthrough_install.md
@@ -25,7 +25,7 @@ When the installation has completed you are prompted to restart your computer.
 2. Run the following command:
 
 ```powershell
-Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V –All
+Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
 ```
 When the installation has completed you need to reboot the computer.
 
@@ -46,4 +46,4 @@ DISM /Online /Enable-Feature /All /FeatureName:Microsoft-Hyper-V
 
 
 ## Next Step - Create a Virtual Switch
-[Create a Virtual Switch](walkthrough_virtual_switch.md) 
+[Create a Virtual Switch](walkthrough_virtual_switch.md)

--- a/virtualization/hyperv_on_windows/quick_start/walkthrough_powershell.md
+++ b/virtualization/hyperv_on_windows/quick_start/walkthrough_powershell.md
@@ -8,7 +8,7 @@ Now that you have walked through the basics of deploying Hyper-V, creating virtu
 2.	Run the following command to display a searchable list of PowerShell commands available with the Hyper-V PowerShell Module.
 
  ```powershell
-get-command –module hyper-v | out-gridview
+get-command -module hyper-v | out-gridview
 ```
   You get something like this:
 
@@ -40,12 +40,12 @@ get-vm
 2. To return a list of only powered on virtual machines add a filter to the `get-vm` command. A filter can be added by using the where-object command. For more information on filtering see the [Using the Where-Object](https://technet.microsoft.com/en-us/library/ee177028.aspx) documentation.   
 
  ```powershell
- get-vm | where {$_.State –eq ‘Running’}
+ get-vm | where {$_.State -eq ‘Running’}
  ```
 3.  To list all virtual machines in a powered off state, run the following command. This command is a copy of the command from step 2 with the filter changed from ‘Running’ to ‘Off’.
 
  ```powershell
- get-vm | where {$_.State –eq ‘Off’}
+ get-vm | where {$_.State -eq ‘Off’}
  ```
 
 ### Start and shut down virtual machines
@@ -53,18 +53,18 @@ get-vm
 1. To start a particular virtual machine, run the following command with name of the virtual machine:
 
  ```powershell
- Start-vm –Name <virtual machine name>
+ Start-vm -Name <virtual machine name>
  ```
 
 2. To start all currently powered off virtual machines, get a list of those machines and pipe the list to the 'start-vm' command:
 
   ```powershell
- get-vm | where {$_.State –eq ‘Off’} | start-vm
+ get-vm | where {$_.State -eq ‘Off’} | start-vm
  ```
 3. To shut down all running virtual machines, run this:
  
   ```powershell
- get-vm | where {$_.State –eq ‘Running’} | stop-vm
+ get-vm | where {$_.State -eq ‘Running’} | stop-vm
  ```
 
 ### Create a VM checkpoint

--- a/virtualization/hyperv_on_windows/user_guide/checkpoints.md
+++ b/virtualization/hyperv_on_windows/user_guide/checkpoints.md
@@ -6,7 +6,7 @@ Windows 10 Hyper-V includes two types of checkpoints:
 
 * **Standard Checkpoints** -- takes a snapshot of the virtual machine and virtual machine memory state at the time the checkpoint is initiated. A snapshot is not a full backup and can cause data consistancy issues with systems that replicate data between different nodes such as Active Directory.  Hyper-V only offered standard checkpoints (formerly called snapshots) prior to Windows 10.
 
-* **Production Checkpoints** –- uses Volume Shadow Copy Service or File System Freeze on a Linux virtual machine to create a data conistenant back of the virtual machine.
+* **Production Checkpoints** -- uses Volume Shadow Copy Service or File System Freeze on a Linux virtual machine to create a data conistenant back of the virtual machine.
 
 Production checkpoints are selected by default however this can be changed using either Hyper-V manager or PowerShell.
 
@@ -60,7 +60,7 @@ To create a checkpoint:
 Create a checkpoint using the **CheckPoint-VM** command.  
 
 ```powershell
-Checkpoint-VM –Name <VMName>
+Checkpoint-VM -Name <VMName>
 ```
 
 When the checkpoint process has completed, view a list of checkpoints for a virtual machine use the **Get-VMCheckpoint** command.
@@ -104,7 +104,7 @@ Many checkpoints are created at a specific point.  Giving them an identifyable n
 By default, the name of a checkpoint is the name of the virtual machine combined with the date and time the checkpoint was taken. This is the standard format: 
 
 ```
-virtual_machine_name (MM/DD/YYY –hh:mm:ss AM\PM)
+virtual_machine_name (MM/DD/YYY -hh:mm:ss AM\PM)
 ```
 
 Names are limited to 100 characters or less, and the name cannot be blank. 
@@ -119,7 +119,7 @@ Names are limited to 100 characters or less, and the name cannot be blank.
 **Using PowerShell**
 
 ``` powershell
-Rename-VMCheckpoint –VMName <virtual machine name> –Name <checkpoint name> --NewName <new checkpoint name>
+Rename-VMCheckpoint -VMName <virtual machine name> -Name <checkpoint name> --NewName <new checkpoint name>
 ```
 
 ## Deleting checkpoints
@@ -140,7 +140,7 @@ To cleanly delete a checkpoint:
  
 **Using PowerShell**
 ```powershell
-Remove-VMCheckpoint –VMName <virtual machine name> –Name <checkpoint name>
+Remove-VMCheckpoint -VMName <virtual machine name> -Name <checkpoint name>
 ```
 
 ## Exporting checkpoints
@@ -149,7 +149,7 @@ Export bundles the checkpoint as a virtual machine so the checkpoint can be move
 
 **Using PowerShell**
 ``` powershell
-Export-VMCheckpoint –VMName <virtual machine name>  –Name <checkpoint name> -Path <path for export>
+Export-VMCheckpoint -VMName <virtual machine name>  -Name <checkpoint name> -Path <path for export>
 ```
 
 ## Enable or disable checkpoints

--- a/virtualization/hyperv_on_windows/user_guide/export_import.md
+++ b/virtualization/hyperv_on_windows/user_guide/export_import.md
@@ -92,7 +92,7 @@ Import-VM -Path ‘C:\<vm export path>\2B91FEB3-F1E0-4FFF-B8BE-29CED892A95A.vmcx
 To complete a copy import and move the virtual machine files to the default Hyper-V location, the command would be similar to this.
 
 ``` PowerShell
-Import-VM -Path 'C:\<vm export path>\2B91FEB3-F1E0-4FFF-B8BE-29CED892A95A.vmcx' –Copy -GenerateNewId
+Import-VM -Path 'C:\<vm export path>\2B91FEB3-F1E0-4FFF-B8BE-29CED892A95A.vmcx' -Copy -GenerateNewId
 ```
 
 For more information, see [Import-VM](https://technet.microsoft.com/library/hh848495.aspx).

--- a/virtualization/windowscontainers/deployment/deployment.md
+++ b/virtualization/windowscontainers/deployment/deployment.md
@@ -213,7 +213,7 @@ If the container host itself will be running on a Hyper-V virtual machine, and w
 **Note** - The virtual machines must be turned off when running this command.
 
 ```poweshell
-PS C:\> Set-VMProcessor –VMName <VM Name> -Count 2
+PS C:\> Set-VMProcessor -VMName <VM Name> -Count 2
 ``` 
 
 ### <a name=dyn></a>Disable Dynamic Memory

--- a/virtualization/windowscontainers/deployment/deployment_nano.md
+++ b/virtualization/windowscontainers/deployment/deployment_nano.md
@@ -98,7 +98,7 @@ PS C:\> Copy-Item $WindowsMedia\NanoServer\Convert-WindowsImage.ps1 c:\nano
 
 PS C:\> Copy-Item $WindowsMedia\NanoServer\NanoServerImageGenerator.psm1 c:\nano
 ```
-Run the following to create a Nano Server virtual hard drive. The `–Containers` parameter indicates that the container package is installed, and the `–Compute` parameter takes care of the Hyper-V package. Hyper-V is only required if using Hyper-V containers.
+Run the following to create a Nano Server virtual hard drive. The `-Containers` parameter indicates that the container package is installed, and the `-Compute` parameter takes care of the Hyper-V package. Hyper-V is only required if using Hyper-V containers.
 
 ```powershell
 PS C:\> Import-Module C:\nano\NanoServerImageGenerator.psm1
@@ -206,7 +206,7 @@ If the container host itself will be running on a Hyper-V virtual machine, and w
 **Note** - The virtual machines must be turned off when running this command.
 
 ```poweshell
-PS C:\> Set-VMProcessor –VMName <VM Name> -Count 2
+PS C:\> Set-VMProcessor -VMName <VM Name> -Count 2
 ``` 
 
 ### <a name=dyn></a>Disable Dynamic Memory

--- a/virtualization/windowscontainers/deployment/docker_windows.md
+++ b/virtualization/windowscontainers/deployment/docker_windows.md
@@ -30,7 +30,7 @@ Create a directory named `c:\programdata\docker`. In this directory, create a fi
 PS C:\> New-Item -ItemType File -Path C:\ProgramData\Docker\runDockerDaemon.cmd -Force
 ```
 
-Copy the following text into the `runDockerDaemon.cmd` file. This batch file starts the Docker daemon with the command `docker daemon –D –b “Virtual Switch”`. Note: the name of the virtual switch in this file, will need to match the name of the virtual switch that containers will be using for network connectivity.
+Copy the following text into the `runDockerDaemon.cmd` file. This batch file starts the Docker daemon with the command `docker daemon -D -b “Virtual Switch”`. Note: the name of the virtual switch in this file, will need to match the name of the virtual switch that containers will be using for network connectivity.
 
 ```powershell
 @echo off

--- a/virtualization/windowscontainers/management/container_networking.md
+++ b/virtualization/windowscontainers/management/container_networking.md
@@ -110,7 +110,7 @@ The external virtual switch can now be connected to a container, which is then c
 When starting the Docker daemon, a network bridge can be selected. When running Docker on Windows, this is the External or NAT virtual switch. The following example starts the Docker daemon, specifying a virtual switch named `Virtual Switch`.
 
 ```powershell
-Docker daemon –D –b “Virtual Switch” -H 0.0.0.0:2375
+Docker daemon -D -b “Virtual Switch” -H 0.0.0.0:2375
 ```
 
 If you have deployed the container host, and Docker using the scripts provide in the Windows Container Quick Starts, an internal virtual switch is created with a type of NAT, and a Docker service is created and preconfigured to use this switch. To change the virtual switch that the Docker service is using, the Docker service needs to be stopped, a configuration file modified, and the service started again.

--- a/virtualization/windowscontainers/management/hyperv_container.md
+++ b/virtualization/windowscontainers/management/hyperv_container.md
@@ -65,7 +65,7 @@ DEMO               HyperV
 
 ### Create Container <!--docker-->
 
-Managing Hyper-V Containers with Docker is almost identical to managing Windows Server Containers. When creating a Hyper-V Container with Docker, the `–-isolation=hyperv` parameter is used.
+Managing Hyper-V Containers with Docker is almost identical to managing Windows Server Containers. When creating a Hyper-V Container with Docker, the `--isolation=hyperv` parameter is used.
 
 ```powershell
 docker run -it --isolation=hyperv 646d6317b02f cmd
@@ -136,7 +136,7 @@ PS C:\> Start-Container $con
 Create Remote PS Session with the container.
 
 ```powershell
-PS C:\> Enter-PSSession -ContainerId $con.ContainerId –RunAsAdministrator
+PS C:\> Enter-PSSession -ContainerId $con.ContainerId -RunAsAdministrator
 ```
 
 From the remote container session return all processes with a process name of csrss. Take note of the process id for the running csrss process (1228 in the example below).
@@ -190,7 +190,7 @@ PS C:\> Start-Container $con
 Create a remote PS session with the Hyper-V container.
 
 ```powershell
-PS C:\> Enter-PSSession -ContainerId $con.ContainerId –RunAsAdministrator
+PS C:\> Enter-PSSession -ContainerId $con.ContainerId -RunAsAdministrator
 ```
 
 Return a list of csrss process running inside the Hyper-V container. Take note of the process id for the csrss process (956 in the below example).

--- a/virtualization/windowscontainers/management/manage_containers.md
+++ b/virtualization/windowscontainers/management/manage_containers.md
@@ -84,7 +84,7 @@ PowerShell direct can be used to connect to a container. This may be helpful if 
 To create an interactive session with the container, use the `Enter-PSSession` command.
 
  ```powershell
-PS C:\> Enter-PSSession -ContainerName demo –RunAsAdministrator
+PS C:\> Enter-PSSession -ContainerName demo -RunAsAdministrator
 ```
 
 Notice that once the remote PowerShell session has been created, the shell prompt changes to reflect the container name.

--- a/virtualization/windowscontainers/management/manage_images.md
+++ b/virtualization/windowscontainers/management/manage_images.md
@@ -48,7 +48,7 @@ NanoServer           10.0.10586.0            Container OS Image of Windows Serve
 WindowsServerCore    10.0.10586.0            Container OS Image of Windows Server 2016 Techn...
 ```
 
-To download and install the Nano Server base OS image, run the following. The `–version` parameter is optional. Without a base OS image version specified, the latest version will be installed.
+To download and install the Nano Server base OS image, run the following. The `-version` parameter is optional. Without a base OS image version specified, the latest version will be installed.
 
 ```powershell
 PS C:\> Install-ContainerImage -Name NanoServer -Version 10.0.10586.0
@@ -56,7 +56,7 @@ PS C:\> Install-ContainerImage -Name NanoServer -Version 10.0.10586.0
 Downloaded in 0 hours, 0 minutes, 10 seconds.
 ```
 
-Likewaise, this command will download and install the Windows Server Core base OS image. The `–version` parameter is optional. Without a base OS image version specified, the latest version will be installed.
+Likewaise, this command will download and install the Windows Server Core base OS image. The `-version` parameter is optional. Without a base OS image version specified, the latest version will be installed.
 
 > **Issue** Save-ContainerImage and Install-ContainerImage cmdlets fail to work with a WindowsServerCore container image in a PowerShell remoting session. **Workaround:** Logon to the machine using Remote Desktop and use Save-ContainerImage cmdlet directly.
 

--- a/virtualization/windowscontainers/management/manage_resources.md
+++ b/virtualization/windowscontainers/management/manage_resources.md
@@ -15,7 +15,7 @@ Windows Containers include the ability to manage how much CPU, disk IO, network 
 Container memory limits can be set when a container is created using the `-MaximumMemoryBytes` parameter of the `New-Container` command. This example sets maximum memory to 256mb.
  
 ```powershell
-PS C:\> New-Container –Name TestContainer –MaximumMemoryBytes 256MB -ContainerimageName WindowsServerCore
+PS C:\> New-Container -Name TestContainer -MaximumMemoryBytes 256MB -ContainerimageName WindowsServerCore
 ```
 You can also set the memory limit of an existing container using the `Set-ContainerMemory` cmdlet.
 
@@ -30,7 +30,7 @@ Network bandwidth limits can be set on an exsisting container. To do so, ensure 
 The below sample the maximum bandwitch to 100Mbps.
 
 ```powershell
-PS C:\> Set-ContainerNetworkAdapter –ContainerName TestContainer –MaximumBandwidth 100000000
+PS C:\> Set-ContainerNetworkAdapter -ContainerName TestContainer -MaximumBandwidth 100000000
 ```
 
 ### CPU 
@@ -40,10 +40,10 @@ You can limit the amount of compute a container can use by either setting a Maxi
 The below sets the relative weight of the container to 1000. The default weight of a container is 100, so this container while have 10 times the priority of a container set to the default. The max value is 10000.
 
 ```powershell
-PS C:\> Set-ContainerProcessor -ContainerName Container1 –RelativeWeight 10000
+PS C:\> Set-ContainerProcessor -ContainerName Container1 -RelativeWeight 10000
 ```
  
-You can also set a hard limit on the amount of CPU a container can use in terms of percentage of CPU time. By default, a container can use 100% of the CPU. The below sets the max percent of a CPU a container can use to 30%. Using the –Maximum flag automatically sets the RelativeWeight to 100. 
+You can also set a hard limit on the amount of CPU a container can use in terms of percentage of CPU time. By default, a container can use 100% of the CPU. The below sets the max percent of a CPU a container can use to 30%. Using the -Maximum flag automatically sets the RelativeWeight to 100. 
 
 ```powershell
 PS C:\> Set-ContainerProcessor -ContainerName Container1 -Maximum 30
@@ -69,7 +69,7 @@ We offer the ability to manage a subset of container resources through Docker. S
 CPU shares amongst containers can be managed at runtime via the --cpu-shares flag. By default, all containers enjoy an equal proportion of CPU time. To change the relative share of CPU that containers use run the --cpu-shares flag with a value from 1-10000. By default, all containers receive a weight of 5000. For more information on CPU share constraint see the [Docker Run Reference]( https://docs.docker.com/engine/reference/run/#cpu-share-constraint). 
 
 ```powershell 
-C:\> docker run –it --cpu-shares 2 --name dockerdemo windowsservercore cmd
+C:\> docker run -it --cpu-shares 2 --name dockerdemo windowsservercore cmd
 ```
 
 ## Known Issues

--- a/virtualization/windowscontainers/quick_start/container_setup.md
+++ b/virtualization/windowscontainers/quick_start/container_setup.md
@@ -34,7 +34,7 @@ Before downloading and running the script, ensure that an external Hyper-V virtu
 Run the following to return a list of external virtual switches. If nothing is returned, create a new external virtual switch, and then proceed to the next step of this guide.
 
 ```powershell
-PS C:\> Get-VMSwitch | where {$_.SwitchType –eq “External”}
+PS C:\> Get-VMSwitch | where {$_.SwitchType -eq “External”}
 ```
 
 Use the following command to download the configuration script. The script can also be manually downloaded from this location - [Configuration Script](https://aka.ms/tp4/New-ContainerHost).
@@ -46,7 +46,7 @@ PS C:\> wget -uri https://aka.ms/tp4/New-ContainerHost -OutFile c:\New-Container
 Run the following command to create and configure the container host, where `<containerhost>` will be the virtual machine name.
 
 ``` powershell
-PS C:\> powershell.exe -NoProfile c:\New-ContainerHost.ps1 –VmName testcont -WindowsImage ServerDatacenterCore -Hyperv
+PS C:\> powershell.exe -NoProfile c:\New-ContainerHost.ps1 -VMName testcont -WindowsImage ServerDatacenterCore -Hyperv
 ```
 
 When the script begins, you will be prompted for a password. This will be the password assigned to the Administrator account.


### PR DESCRIPTION
I just followed the PowerShell steps in https://msdn.microsoft.com/en-us/virtualization/hyperv_on_windows/quick_start/walkthrough_install and found a problem in the chapter **Install Hyper-V with PowerShell** in step 2. Putting that command line into a script results in an error message:

```
==> default: At C:\tmp\vagrant-shell.ps1:2 char:72
==> default: + ... -WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V â€“All
==> default: +                                                                      ~~~~
==> default: The string is missing the terminator: ".
==> default:     + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
==> default:     + FullyQualifiedErrorId : TerminatorExpectedAtEndOfString
==> default:  
```

I had a closer look and found that the dash is wrong. This is a typical problem with word processors that "uglify" code blocks into a unusable variant for a copy-paste scenario.

I also replaced all the other wrong dashes with a simple minus sign.
Now the code could be easily copied from the web page into the command line or a script with that problem.
