### PR TITLE
Update manage_images.md

### DIFF
--- a/virtualization/windowscontainers/management/manage_images.md
+++ b/virtualization/windowscontainers/management/manage_images.md
@@ -13,6 +13,8 @@ There are two types of container images:
 - Base OS Images – these are provided by Microsoft and include the core OS components. 
 - Container Images – a container image that has been created from a Base OS Image.
 
+**Using the Install-ContainerImage cmdlet installs a BASE OS image for use in either PowerShell or Docker managed containers.  If you download a BASE OS image and it does not show up under Docker after downloading.  Restart the Docker service using the services control panel applet or the command 'sc docker stop' and then 'sc docker start'
+
 ## PowerShell
 
 ### List Images <!--1-->


### PR DESCRIPTION
Given that we currently only manage container images in either powershell OR docker, when running a powershell cmdlet to install a BASEOS image, naturally one would assume there is a DOCKER command to do the same.  However BASEOS images are available to both management tool sets.  it is not clear here.  What further complicates the issue is that when an image is added, it doesn't immediately show up in DOCKER, and only showed up after I had restarted the Daemon.  Probably known issue, probably not going to be broken in GA.  Definitely useful now, would have saved me 30 / 40 minutes of searching.