### PR TITLE
Update deployment.md

### DIFF
--- a/virtualization/windowscontainers/deployment/deployment.md
+++ b/virtualization/windowscontainers/deployment/deployment.md
@@ -107,7 +107,7 @@ Each container needs to be attached to a virtual switch in order to communicate 
 This example creates a virtual switch with the name “Virtual Switch”, a type of NAT, and Nat Subnet of 172.16.0.0/12. 
 
 ```powershell
-PS C:\> New-VMSwitch -Name "Virtual Switch" -SwitchType NAT -NATSubnetAddress 172.16.0.0/12
+PS C:\> New-VMSwitch -Name "Virtual Switch" -SwitchType NAT -NATSubnetAddress "172.16.0.0/12"
 ```
 
 ### <a name=nat></a>Configure NAT


### PR DESCRIPTION
Add quotation marks around the -NATSubnetAddress parameter values for New-VMSwitch. Doing so prevents an error from occurring in the PowerShell command line.