### PR TITLE
Fix the use of undefined $dockerData

### DIFF
--- a/windows-server-container-tools/Install-ContainerHost/Install-ContainerHost.ps1
+++ b/windows-server-container-tools/Install-ContainerHost/Install-ContainerHost.ps1
@@ -561,7 +561,7 @@ RUN echo "Building first boot layer..."
             }
         }
 
-        "tag complete" | Out-File -FilePath "$dockerData\tag.txt" -Encoding ASCII
+        "tag complete" | Out-File -FilePath "$($env:ProgramData)\docker\tag.txt" -Encoding ASCII
 
         #
         # if certs.d exists, restart docker in TLS mode


### PR DESCRIPTION
$dockerData is not defined in the scope of the Install-ContainerHost function and hence tag.txt gets created in c:\ rather than the intended $($env:ProgramData)\docker
