### PR TITLE
Fix typo: container

### DIFF
--- a/virtualization/windowscontainers/TOC.md
+++ b/virtualization/windowscontainers/TOC.md
@@ -7,7 +7,7 @@
 ## [1 – Get Started with Containers](quick_start/quick_start.md)
 ## [2 - Configure a Container Host](quick_start/quick_start_configure_host.md)
 ## [3 – Windows Server Containers](quick_start/manage_docker.md)
-## [4 – Hyper-V Contianers](quick_start/manage_docker_hyperv.md)
+## [4 – Hyper-V Containers](quick_start/manage_docker_hyperv.md)
 
 # Deploy Windows Containers
 ## [System Requirements](deployment/system_requirements.md)

--- a/virtualization/windowscontainers/about/about_overview.md
+++ b/virtualization/windowscontainers/about/about_overview.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 8e273856-3620-4e58-9d1a-d1e06550448
 ---

--- a/virtualization/windowscontainers/about/container_ecosystem.md
+++ b/virtualization/windowscontainers/about/container_ecosystem.md
@@ -6,7 +6,7 @@ author: scooley
 manager: timlt
 ms.date: 04/20/2016
 ms.topic: about-article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 29fbe13a-228a-4eaa-9d4d-90ae60da5965
 ---

--- a/virtualization/windowscontainers/about/faq.md
+++ b/virtualization/windowscontainers/about/faq.md
@@ -6,7 +6,7 @@ author: scooley
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 25de368c-5a10-40a4-b4aa-ac8c9a9ca022
 ---

--- a/virtualization/windowscontainers/about/work_in_progress.md
+++ b/virtualization/windowscontainers/about/work_in_progress.md
@@ -6,7 +6,7 @@ author: scooley
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 5d9f1cb4-ffb3-433d-8096-b085113a9d7b
 ---

--- a/virtualization/windowscontainers/containers_welcome.md
+++ b/virtualization/windowscontainers/containers_welcome.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 74c9d604-0915-4d89-bc69-0263b76bc66b
 ---

--- a/virtualization/windowscontainers/deployment/deployment.md
+++ b/virtualization/windowscontainers/deployment/deployment.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: ba4eb594-0cdb-4148-81ac-a83b4bc337bc
 ---

--- a/virtualization/windowscontainers/deployment/deployment_nano.md
+++ b/virtualization/windowscontainers/deployment/deployment_nano.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: b82acdf9-042d-4b5c-8b67-1a8013fa1435
 ---

--- a/virtualization/windowscontainers/deployment/docker_windows.md
+++ b/virtualization/windowscontainers/deployment/docker_windows.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: bdfa4545-2291-4827-8165-2d6c98d72d37
 ---

--- a/virtualization/windowscontainers/deployment/system_requirements.md
+++ b/virtualization/windowscontainers/deployment/system_requirements.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 04/20/2016
 ms.topic: deployment-article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 3c3d4c69-503d-40e8-973b-ecc4e1f523ed
 ---

--- a/virtualization/windowscontainers/docker/manage_windows_dockerfile.md
+++ b/virtualization/windowscontainers/docker/manage_windows_dockerfile.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 75fed138-9239-4da9-bce4-4f2e2ad469a1
 ---

--- a/virtualization/windowscontainers/docker/optimize_windows_dockerfile.md
+++ b/virtualization/windowscontainers/docker/optimize_windows_dockerfile.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: bb2848ca-683e-4361-a750-0d1d14ec8031
 ---

--- a/virtualization/windowscontainers/management/container_networking.md
+++ b/virtualization/windowscontainers/management/container_networking.md
@@ -6,7 +6,7 @@ author: jmesser81
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 538871ba-d02e-47d3-a3bf-25cda4a40965
 ---

--- a/virtualization/windowscontainers/management/hcs_powershell.md
+++ b/virtualization/windowscontainers/management/hcs_powershell.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 45144ec5-f76a-4460-abd1-9b60e47506d6
 ---

--- a/virtualization/windowscontainers/management/hyperv_container.md
+++ b/virtualization/windowscontainers/management/hyperv_container.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 42154683-163b-47a1-add4-c7e7317f1c04
 ---

--- a/virtualization/windowscontainers/management/manage_data.md
+++ b/virtualization/windowscontainers/management/manage_data.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: f5998534-917b-453c-b873-2953e58535b1
 ---

--- a/virtualization/windowscontainers/management/manage_images.md
+++ b/virtualization/windowscontainers/management/manage_images.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: d8163185-9860-4ee4-9e96-17b40fb508bc
 ---

--- a/virtualization/windowscontainers/management/manage_resources.md
+++ b/virtualization/windowscontainers/management/manage_resources.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: b2192e64-9d74-474e-8af0-2d8b3ad1deee
 ---

--- a/virtualization/windowscontainers/quick_start/manage_docker.md
+++ b/virtualization/windowscontainers/quick_start/manage_docker.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: b2efa940-d5cc-4afd-a200-b71e1eeed5ed
 ---

--- a/virtualization/windowscontainers/quick_start/manage_docker_hyperv.md
+++ b/virtualization/windowscontainers/quick_start/manage_docker_hyperv.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 7b907b0e-3fa8-4925-8615-bbb5812c2402
 ---

--- a/virtualization/windowscontainers/quick_start/quick_start.md
+++ b/virtualization/windowscontainers/quick_start/quick_start.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 4878f5d2-014f-4f3c-9933-97f03348a147
 ---

--- a/virtualization/windowscontainers/quick_start/quick_start_configure_host.md
+++ b/virtualization/windowscontainers/quick_start/quick_start_configure_host.md
@@ -6,7 +6,7 @@ author: neilpeterson
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 42ea9737-5d0d-447a-96d8-6fd5ed126b25
 ---
@@ -88,7 +88,7 @@ The Install-ContainerHost script can be used to configure Windows containers on 
 
 - Enable nested virtualization - if Hyper-V containers will be deployed and container host is virtualized – [documentation](https://msdn.microsoft.com/en-us/virtualization/windowscontainers/deployment/deployment_nano#-a-name-nest-a-nested-virtualization).
 
-Once the prerequisites have been completed, download and run the Install-ContianerHost script to configure the Windows containers role.
+Once the prerequisites have been completed, download and run the Install-ContainerHost script to configure the Windows containers role.
 
 > Nano Server does not support the wget command. Download the script on a separate system and copy it to the Nano Server system
 

--- a/virtualization/windowscontainers/reference/app_compat.md
+++ b/virtualization/windowscontainers/reference/app_compat.md
@@ -6,7 +6,7 @@ author: scooley
 manager: timlt
 ms.date: 05/02/2016
 ms.topic: article
-ms.prod: windows-contianers
+ms.prod: windows-containers
 ms.service: windows-containers
 ms.assetid: 3e524458-bd03-400e-913f-210335add8dc
 ---


### PR DESCRIPTION
Just saw a typo and fixed all occurrences in the documentation repo.

contianer -> container
