### PR TITLE
Fix quotes in code examples

### DIFF
--- a/demos/2015-Ignite-Whats-New/scripts/WorkloadSetup.ps1
+++ b/demos/2015-Ignite-Whats-New/scripts/WorkloadSetup.ps1
@@ -149,7 +149,7 @@ function CreateBaseVM([string]$VMName, `
          Get-iSCSITarget | Connect-iSCSITarget 
          Get-iSCSISession | Register-iSCSISession
          Get-Disk | ?{$_.BusType -eq "iSCSI"} | %{
-            $d = “WXYZ”[$_.Number] 
+            $d = "WXYZ"[$_.Number]
             Set-Disk -Number $_.Number -IsReadOnly 0 
             Set-Disk -Number $_.Number -IsOffline 0 
             Initialize-Disk -Number $_.Number -PartitionStyle MBR 

--- a/hyperv-samples/benarm-powershell/GuestNameCheck.ps1
+++ b/hyperv-samples/benarm-powershell/GuestNameCheck.ps1
@@ -1,5 +1,5 @@
 # Get the virtual machine name from the parent partition
- $vmName = (Get-ItemProperty -path “HKLM:\SOFTWARE\Microsoft\Virtual Machine\Guest\Parameters”).VirtualMachineName
+ $vmName = (Get-ItemProperty -path "HKLM:\SOFTWARE\Microsoft\Virtual Machine\Guest\Parameters").VirtualMachineName
  # Replace any non-alphanumeric characters with an underscore
  $vmName = [Regex]::Replace($vmName,"\W","_")
  # Trim names that are longer than 15 characters

--- a/hyperv-tools/Convert-WindowsImage/Convert-WindowsImage.psm1
+++ b/hyperv-tools/Convert-WindowsImage/Convert-WindowsImage.psm1
@@ -1584,7 +1584,7 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
                     $VhdPath      = Join-Path  -Path $VhdPath -ChildPath $vhdNameTemp
                 }
 
-                Write-Debug -Message "  Temporary $VhdFormat path is: `“$VhdPath`”"
+                Write-Debug -Message "  Temporary $VhdFormat path is: `"$VhdPath`""
 
            #endregion Prepare variables
 
@@ -1600,7 +1600,7 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
                     {
                         $IsoFileName = Split-Path -Path $SourcePath -Leaf
 
-                        Write-Verbose -Message "Copying ISO `“$IsoFileName`” to temp folder..."
+                        Write-Verbose -Message "Copying ISO `"$IsoFileName`" to temp folder..."
 
                     #    Robocopy.exe $(Split-Path $SourcePath -Parent) $TempDirectory $(Split-Path $SourcePath -Leaf) | Out-Null
                         $Item = Copy-Item -Path $SourcePath -Destination $TempDirectory -PassThru
@@ -1613,7 +1613,7 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
                     $IsoPath     = ( Resolve-Path $SourcePath ).Path
                     $IsoFileName = Split-Path $IsoPath -Leaf
 
-                    Write-Verbose -Message "Opening ISO `“$IsoFileName`”..."
+                    Write-Verbose -Message "Opening ISO `"$IsoFileName`"..."
                     $openIso     = Mount-DiskImage -ImagePath $IsoPath -StorageType "ISO" -PassThru
 
                   # Refresh the DiskImage object so we can get the real information about it.  I assume this is a bug.
@@ -1623,7 +1623,7 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
                     $SourcePath  = "$($driveLetter):\sources\install.wim"
 
                   # Check to see if there's a WIM file we can muck about with.
-                    Write-Verbose -Message "Looking for `“$SourcePath`”..."
+                    Write-Verbose -Message "Looking for `"$SourcePath`"..."
 
                     If (-Not ( Test-Path -Path $SourcePath ))
                     {
@@ -1717,7 +1717,7 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
                     $OpenImageFlags   = $openImage.ImageFlags
                     $OpenImageVersion = $openImage.ImageVersion
 
-                    Write-Verbose -Message "Image $OpenImageIndex selected: `“$OpenImageFlags`”..."
+                    Write-Verbose -Message "Image $OpenImageIndex selected: `"$OpenImageFlags`"..."
 
                   # Check to make sure that the image we're applying is Windows 7 or greater.
                     If ($OpenImageVersion -lt $lowestSupportedVersion)
@@ -1876,10 +1876,10 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
                             }
 
                           # Create the Windows partition
-                            Write-Verbose -Message "Creating Boot (`“Windows`”) partition..."
+                            Write-Verbose -Message "Creating Boot (`"Windows`") partition..."
                             $windowsPartition = New-Partition -DiskNumber $disk.Number -UseMaximumSize -GptType '{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}'
 
-                            Write-Verbose -Message "  Formatting Boot (`“Windows`”) volume..."
+                            Write-Verbose -Message "  Formatting Boot (`"Windows`") volume..."
                             $windowsVolume = Format-Volume -Partition $windowsPartition -FileSystem NTFS -Force -Confirm:$false
                         }
 
@@ -1910,7 +1910,7 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
                       # Retreive access path for System partition.
                         $systemPartition = Get-Partition -UniqueId $systemPartition.UniqueId
                         $systemDrive = $systemPartition.AccessPaths[0].trimend("\").replace("\?", "??")
-                        Write-Verbose -Message "System volume path: `“$systemDrive`”"
+                        Write-Verbose -Message "System volume path: `"$systemDrive`""
                     }
 
                   # Assign drive letter to Boot partition.  This is required for bcdboot
@@ -1944,12 +1944,12 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
 
                     $windowsDrive = ( Get-Partition -Volume $windowsVolume ).AccessPaths[0].substring(0,2)
 
-                  # This is to workaround “No such drive exists” error in PowerShell
+                  # This is to workaround "No such drive exists" error in PowerShell
                     $Drive = Get-psDrive
 
                     $windowsDrive = ( Resolve-Path -Path $windowsDrive ).Path
 
-                    Write-Verbose -Message "Boot volume path: `“$windowsDrive`”. (Took $attempts attempt(s) to assign.)"
+                    Write-Verbose -Message "Boot volume path: `"$windowsDrive`". (Took $attempts attempt(s) to assign.)"
 
                #endregion Create and partition VHD
 
@@ -2310,7 +2310,7 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
                       # ISSUE - do we want VL here?
 
                         $vhdFinalName = "$($buildLabEx)_$($skuFamily)_$($editionId)_$($openImage.ImageDefaultLanguage).$($VhdFormat.ToLower())"
-                        Write-Debug -Message "    $VhdFormat final name is: `“$vhdFinalName`”"
+                        Write-Debug -Message "    $VhdFormat final name is: `"$vhdFinalName`""
                     }
 
                     If ($hyperVEnabled)
@@ -2327,18 +2327,18 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
                     $vhdParentPath = Split-Path -Path $VhdPath -Parent
                     $vhdFinalPath  = Join-Path  -Path $vhdParentPath -ChildPath $vhdFinalName
 
-                    Write-Debug -Message "    $VhdFormat final path is: `“$vhdFinalPath`”"
+                    Write-Debug -Message "    $VhdFormat final path is: `"$vhdFinalPath`""
 
                     If (Test-Path -Path $vhdFinalPath)
                     {
                         $VhdNameOld = Split-Path -Path $vhdFinalPath -Leaf
 
-                        Write-Verbose -Message "Deleting pre-existing $($VhdFormat): `“$VhdNameOld`”..."
+                        Write-Verbose -Message "Deleting pre-existing $($VhdFormat): `"$VhdNameOld`"..."
 
                         Remove-Item -Path $vhdFinalPath -Force
                     }
 
-                    Write-Debug -Message "    Renaming $VhdFormat at `“$VhdPath`”."
+                    Write-Debug -Message "    Renaming $VhdFormat at `"$VhdPath`"."
 
                     $VhdPathFull = ( Resolve-Path -Path $VhdPath ).Path
 
@@ -2355,7 +2355,7 @@ You can use the fields below to configure the VHD or VHDX that you want to creat
         {
             Write-Verbose -Message ( [system.string]::Empty )
             Write-Error   -Message $PSItem
-            Write-Verbose -Message "Log folder is `“$logFolder`”"
+            Write-Verbose -Message "Log folder is `"$logFolder`""
         }
         Finally
         {
@@ -4242,7 +4242,7 @@ VirtualHardDisk
     Add-Type -TypeDefinition $code -ReferencedAssemblies "System.Xml","System.Linq","System.Xml.Linq" -ErrorAction SilentlyContinue
 }
 
-# This is required for renewed “Mount-RegistryHive” and “Dismount-RegistryHive”
+# This is required for renewed "Mount-RegistryHive" and "Dismount-RegistryHive"
 # functions using Windows API. Code borrowed from
 # http://www.leeholmes.com/blog/2010/09/24/adjusting-token-privileges-in-powershell/
 
@@ -4551,7 +4551,7 @@ Start-Executable
         $SuccessfulErrorCode = 0
     )
 
-    Write-Debug -Message "    Running `“$Executable`” with parameters: `“$Arguments`”"
+    Write-Debug -Message "    Running `"$Executable`" with parameters: `"$Arguments`""
 
     $StartProcessParam = @{
 
@@ -4647,10 +4647,10 @@ Import-ModuleEx
 
       # When we have $VerbosePreference defined as "Continue" and import
       # a module (either implicitly, by firt use, or explictily, calling
-      # “Import-Module”), there's a lot of Verbose output listing every cmdlet
+      # "Import-Module"), there's a lot of Verbose output listing every cmdlet
       # and every function. This output provides no value, thus we need
-      # to suppress it. Unfortunately, even if we pass “-Verobse:$False”
-      # to “Import-Module”, it only helps to swallow the list of cmdlets.
+      # to suppress it. Unfortunately, even if we pass "-Verobse:$False"
+      # to "Import-Module", it only helps to swallow the list of cmdlets.
       # The list of functions is still thrown to output. (This is probably
       # a bug). Thus, we need to temporary change $VerbosePreference.
 

--- a/hyperv-tools/Nested/Get-NestedVirtStatus.ps1
+++ b/hyperv-tools/Nested/Get-NestedVirtStatus.ps1
@@ -159,7 +159,7 @@ $hvloadoptions = bcdedit /enum | Select-String "hypervisorloadoptions"
 if ($hvloadoptions) {
     $HostNested.HypervisorLoadOptionsPresent = $true
     $setting = $hvloadoptions.line.split(' ')
-    if($hvloadoptions.line -match “OFFERNESTEDVIRT=FALSE”) {
+    if($hvloadoptions.line -match "OFFERNESTEDVIRT=FALSE") {
         $HostNested.HostNestedSupport = $false
         $HostCfgErrors += ($HostCfgErrorMsgs["BcdDisabled"])
 

--- a/virtualization/windowscontainers/docker/manage_windows_dockerfile.md
+++ b/virtualization/windowscontainers/docker/manage_windows_dockerfile.md
@@ -174,7 +174,7 @@ ADD <source> <destination>
 If either source or destination include whitespace, enclose the path in square brackets and double quotes.
  
 ```none
-ADD [“<source>” “<destination>”]
+ADD ["<source>" "<destination>"]
 ```
 
 **Windows Considerations**

--- a/virtualization/windowscontainers/management/container_networking.md
+++ b/virtualization/windowscontainers/management/container_networking.md
@@ -52,7 +52,7 @@ Stop-Service docker
 The configuration file can be found at `c:\programdata\docker\runDockerDaemon.cmd`. Edit the following line, and add `-b "none"`
 
 ```none
-dockerd -b “none”
+dockerd -b "none"
 ```
 
 Restart the service.

--- a/virtualization/windowscontainers/quick_start/container_setup.md
+++ b/virtualization/windowscontainers/quick_start/container_setup.md
@@ -35,7 +35,7 @@ Before downloading and running the script, ensure that an external Hyper-V virtu
 Run the following to return a list of external virtual switches. If nothing is returned, create a new external virtual switch, and then proceed to the next step of this guide.
 
 ```powershell
-PS C:\> Get-VMSwitch | Where-Object {$_.SwitchType -eq “External”}
+PS C:\> Get-VMSwitch | Where-Object {$_.SwitchType -eq "External"}
 ```
 
 Use the following command to download the configuration script. The script can also be manually downloaded from this location - [Configuration Script](https://aka.ms/tp4/New-ContainerHost).

--- a/virtualization/windowscontainers/removed/dotnet35.md
+++ b/virtualization/windowscontainers/removed/dotnet35.md
@@ -47,7 +47,7 @@ To create a new image using PowerShell, a container will be created, modified wi
 Create a new container form the Windows Server Core base image.
 
 ```powershell
-New-Container -Name dotnet35 -ContainerImageName windowsservercore -SwitchName “Virtual Switch”
+New-Container -Name dotnet35 -ContainerImageName windowsservercore -SwitchName "Virtual Switch"
 ```
 
 Create a shared folder with the new container. This will be used to make the .NET 3.5 cab file accessible inside of the new container.  Note, the container must be stopped when running the following command.
@@ -106,7 +106,7 @@ Run `docker build` which will consume the dockerfile and create the new containe
 Docker build -t dotnet35 C:\dotnet3.5\
 ```
 
-Run “docker images” to see the new image. This image can now be used to run a container with the .NET 3.5 framework pre-installed.
+Run `docker images` to see the new image. This image can now be used to run a container with the .NET 3.5 framework pre-installed.
 
 ```powershell
 docker images


### PR DESCRIPTION
This fixes all code examples to use double quotes and to make them copy-pastable for readers.
