### PR TITLE
split ping command into arguments array

### DIFF
--- a/windows-container-samples/windowsservercore/iis/Dockerfile
+++ b/windows-container-samples/windowsservercore/iis/Dockerfile
@@ -6,4 +6,4 @@ LABEL Description="IIS" Vendor=Microsoft" Version="10"
 
 RUN powershell -Command Add-WindowsFeature Web-Server
 
-CMD [ "ping localhost -t" ]
+CMD [ "ping", "localhost", "-t" ]


### PR DESCRIPTION
This fixes error when running container as follows "C:\Windows\system32\docker.exe: Error response from daemon: Container command 'ping localhost -t' not found or does not exist." This is occurring in the latest Tech Preview.