### PR TITLE
Update Apache VC11 version

### DIFF
--- a/windows-container-samples/windowsservercore/apache-http-php/dockerfile
+++ b/windows-container-samples/windowsservercore/apache-http-php/dockerfile
@@ -3,11 +3,11 @@
 
 FROM windowsservercore
 
-LABEL Description="Apache-PHP" Vendor1="Apache Software Foundation" Version1="2.4.18" Vendor2="The PGP Group" Version2="5.5.33"
+LABEL Description="Apache-PHP" Vendor1="Apache Software Foundation" Version1="2.4.20" Vendor2="The PGP Group" Version2="5.5.33"
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri https://www.apachelounge.com/download/VC11/binaries/httpd-2.4.18-win32-VC11.zip -OutFile c:\apache.zip ; \
+	Invoke-WebRequest -Method Get -Uri https://www.apachelounge.com/download/VC11/binaries/httpd-2.4.20-win32-VC11.zip -OutFile c:\apache.zip ; \
 	Expand-Archive -Path c:\apache.zip -DestinationPath c:\ ; \
 	Remove-Item c:\apache.zip -Force
 


### PR DESCRIPTION
Previous version 2.4.18 cannot be downloaded.