### PR TITLE
Fix code samples

### DIFF
--- a/virtualization/hyperv_on_windows/user_guide/create_pre-release_vm.md
+++ b/virtualization/hyperv_on_windows/user_guide/create_pre-release_vm.md
@@ -22,9 +22,9 @@ The virtual machines you create as pre-release have no build-to-build compatibil
 
 Here are some more reasons why these are for non-production environments only:
 
-* There is no forward compatibility for pre-release virtual machines. You can't upgrade these virtual machines to a new configuration version. 
+* There is no forward compatibility for pre-release virtual machines. You can't upgrade these virtual machines to a new configuration version.
 * Pre-release virtual machines don't have a consistent definition between builds. If you update the host operating system, existing pre-release virtual machines may be incompatible with the host. These virtual machines may not start, or may initially appear to work but later run into significant compatibility issues.
-* If you import a pre-release virtual machine to a host with a different build, the results are unpredictable. You can move a pre-release virtual machine to another host. But this scenario is only expected to work if both hosts are running the same build. 
+* If you import a pre-release virtual machine to a host with a different build, the results are unpredictable. You can move a pre-release virtual machine to another host. But this scenario is only expected to work if both hosts are running the same build.
 
 ## Create a pre-release virtual machine
 
@@ -35,12 +35,12 @@ You can create a pre-release virtual machine on Hyper-V hosts that run Windows S
 3. Use the [New-VM](https://technet.microsoft.com/library/hh848537.aspx) cmdlet with the -Prerelease flag to create the pre-release virtual machine. For example, run the following command where VM Name is the name of the virtual machine that you want to create.
 
 ``` PowerShell
-New-VM -Name <VM Name> –Prerelease 
+New-VM -Name <VM Name> -Prerelease
 ```
 Other examples you can use the -Prerelease flag with:
- - To create a virtual machine that uses an existing virtual hard disk or a new hard disk, see the PowerShell examples in [Create a virtual machine in Hyper-V on Windows Server 2016 Technical Preview](https://technet.microsoft.com/library/mt126140.aspx#BKMK_PowerShell). 
- - To create a new virtual hard disk that boots to an operating system image, see the PowerShell example in [Deploy a Windows Virtual Machine in Hyper-V on Windows 10](https://msdn.microsoft.com/en-us/virtualization/hyperv_on_windows/quick_start/walkthrough_create_vm). 
- 
+ - To create a virtual machine that uses an existing virtual hard disk or a new hard disk, see the PowerShell examples in [Create a virtual machine in Hyper-V on Windows Server 2016 Technical Preview](https://technet.microsoft.com/library/mt126140.aspx#BKMK_PowerShell).
+ - To create a new virtual hard disk that boots to an operating system image, see the PowerShell example in [Deploy a Windows Virtual Machine in Hyper-V on Windows 10](https://msdn.microsoft.com/en-us/virtualization/hyperv_on_windows/quick_start/walkthrough_create_vm).
+
  The examples covered in those articles work for Hyper-V hosts that run Windows 10 or Windows Server 2016 Technical Preview. But right now, you can only use the -Prerelease flag to create a pre-release virtual machine on Hyper-V hosts that run Windows Server 2016 Technical Preview.
 
 ## See also

--- a/virtualization/hyperv_on_windows/user_guide/setup_nat_network.md
+++ b/virtualization/hyperv_on_windows/user_guide/setup_nat_network.md
@@ -33,7 +33,7 @@ Network Address Translation (NAT) is a networking mode designed to conserve IP a
 
 Additionally, NAT allows multiple virtual machines to host applications that require identical (internal) communication ports by mapping these to unique external ports.
 
-For all of these reasons, NAT networking is very common for container technology (see [Container Networking](https://msdn.microsoft.com/en-us/virtualization/windowscontainers/management/container_networking)). 
+For all of these reasons, NAT networking is very common for container technology (see [Container Networking](https://msdn.microsoft.com/en-us/virtualization/windowscontainers/management/container_networking)).
 
 
 ## Create a NAT virtual network
@@ -42,40 +42,40 @@ Let's walk through setting up a new NAT network.
 1.  Open a PowerShell console as Administrator.  
 
 2. Create an internal switch  
-  
+
   ``` PowerShell
-  New-VMSwitch –SwitchName “SwitchName” –SwitchType Internal
+  New-VMSwitch -SwitchName "SwitchName" -SwitchType Internal
   ```
 
 3. Configure the NAT gateway using [New-NetIPAddress](https://technet.microsoft.com/en-us/library/hh826150.aspx).  
-  
+
   Here is the generic command:
   ``` PowerShell
-  New-NetIPAddress –IPAddress <NAT Gateway IP> -PrefixLength <NAT Subnet Prefix Length> -InterfaceIndex <ifIndex>
+  New-NetIPAddress -IPAddress <NAT Gateway IP> -PrefixLength <NAT Subnet Prefix Length> -InterfaceIndex <ifIndex>
   ```
-  
+
   In order to configure the gateway, you'll need a bit of information about your network:  
   * **IPAddress** -- NAT Gateway IP specifies the IPv4 or IPv6 address to use as the NAT gateway IP.  
     The generic form will be a.b.c.1 (e.g. 172.16.0.1).  While the final position doesn’t have to be .1, it usually is (based on prefix length)
-    
+
     A common gateway IP is 192.168.0.1  
-  
-  * **PrefixLength** --  NAT Subnet Prefix Length defines the NAT local subnet size (subnet mask). 
+
+  * **PrefixLength** --  NAT Subnet Prefix Length defines the NAT local subnet size (subnet mask).
     The subnet prefix length will be an integer value between 0 and 32.
-    
+
     0 would map the entire internet, 32 would only allow one mapped IP.  Common values range from 24 to 12 depending on how many IPs need to be attached to the NAT.
-     
+
     A common PrefixLength is 24 -- this is a subnet mask of 255.255.255.0
-  
+
   * **InterfaceIndex** -- ifIndex is the interface index of the virtual switch created above.
-    
+
     You can find the interface index by running `Get-NetAdapter`
-    
+
     Your output should look something like this:
-    
+
     ```
     PS C:\> Get-NetAdapter
-    
+
     Name                  InterfaceDescription               ifIndex Status       MacAddress           LinkSpeed
     ----                  --------------------               ------- ------       ----------           ---------
     vEthernet (intSwitch) Hyper-V Virtual Ethernet Adapter        24 Up           00-15-5D-00-6A-01      10 Gbps
@@ -83,38 +83,38 @@ Let's walk through setting up a new NAT network.
     Bluetooth Network ... Bluetooth Device (Personal Area...      21 Disconnected 98-5F-D3-34-0C-D4       3 Mbps
 
     ```
-    
+
     The internal switch will have a name like `vEthernet (SwitchName)` and an Interface Description of `Hyper-V Virtual Ethernet Adapter`.
-  
+
   Run the following to create the NAT Gateway:
-    
+
   ``` PowerShell
-  New-NetIPAddress – IPAddress 192.168.0.1 -PrefixLength 24 -InterfaceIndex 24
+  New-NetIPAddress -IPAddress 192.168.0.1 -PrefixLength 24 -InterfaceIndex 24
   ```
 
 4. Configure the NAT network using [New-NetNat](https://technet.microsoft.com/en-us/library/dn283361(v=wps.630).aspx).  
-  
+
   Here is the generic command:
-    
+
   ``` PowerShell
-  New-NetNat –Name <NATOutsideName> –InternalIPInterfaceAddressPrefix <NAT subnet prefix>
+  New-NetNat -Name <NATOutsideName> -InternalIPInterfaceAddressPrefix <NAT subnet prefix>
   ```
-  
+
   In order to configure the gateway, you'll need to provide information about the network and NAT Gateway:  
   * **Name** -- NATOutsideName describes the name of the NAT network.  You'll use this to remove the NAT network.
-  
+
   * **InternalIPInterfaceAddressPrefix** -- NAT subnet prefix describes both the NAT Gateway IP prefix from above as well as the NAT Subnet Prefix Length from above.
-    
-    The generic form will be a.b.c.0/NAT Subnet Prefix Length 
-    
+
+    The generic form will be a.b.c.0/NAT Subnet Prefix Length
+
     From the above, for this example, we'll use 192.168.0.0/24
-  
+
   For our example, run the following to setup the NAT network:
-  
+
   ``` PowerShell
-  New-NetNat –Name MyNATnetwork –InternalIPInterfaceAddressPrefix 192.168.0.0/24
+  New-NetNat -Name MyNATnetwork -InternalIPInterfaceAddressPrefix 192.168.0.0/24
   ```
-  
+
 Congratulations!  You now have a virtual NAT network!  To add a virtual machine, to the NAT network follow [these instructions](setup_nat_network.md#connect-a-virtual-machine).
 
 ## Connect a virtual machine
@@ -127,25 +127,25 @@ To connect a virtual machine to your new NAT network, connect the internal switc
 This workflow assumes that there are no other NATs on the host. However, sometimes multiple applications or services will require the use of a NAT. Since Windows (WinNAT) only supports one internal NAT subnet prefix, trying to create multiple NATs will place the system into an unknown state.
 
 ### Troubleshooting Steps
-1. Make sure you only have one NAT 
-  
+1. Make sure you only have one NAT
+
   ``` PowerShell
   Get-NetNat
   ```
 2. If a NAT already exists, please delete it
-  
+
   ``` PowerShell
   Get-NetNat | Remove-NetNat
   ```
 
 3. Make sure you only have one "internal" vmSwitch for the NAT. Record the name of the vSwitch for Step 4
-  
+
   ``` PowerShell
   Get-VMSwitch
   ```
 
 4. Check to see if there are private IP addresses (e.g. NAT default Gateway IP Address - usually *.1) from the old NAT still assigned to an adapter
-  
+
   ``` PowerShell
   Get-NetIPAddress -InterfaceAlias "vEthernet(<name of vSwitch>)"
   ```
@@ -161,13 +161,13 @@ Some scenarios require multiple applications or services to use the same NAT. In
 
 **_We will detail the Docker 4 Windows - Docker Beta - Linux VM co-existing with the Windows Container feature on the same host as an example. This workflow is subject to change_**
 
-1. C:\> net stop docker 
-2. Stop Docker4Windows MobyLinux VM 
-3. PS C:\> Get-ContainerNetwork | remove-containerNetwork -force  
+1. C:\> net stop docker
+2. Stop Docker4Windows MobyLinux VM
+3. PS C:\> Get-ContainerNetwork | Remove-ContainerNetwork -force
 4. PS C:\> Get-NetNat | Remove-NetNat  
    *Removes any previously existing container networks (i.e. deletes vSwitch, deletes NetNat, cleans up)*  
 
-5. New-containernetwork –name nat –Mode NAT –subnetprefix 10.0.76.0/24 (this subnet will be used for Windows containers feature)  
+5. New-ContainerNetwork -Name nat -Mode NAT –subnetprefix 10.0.76.0/24 (this subnet will be used for Windows containers feature)
    *Creates internal vSwitch named nat*  
    *Creates NAT network named “nat” with IP prefix 10.0.76.0/24*  
 
@@ -183,7 +183,7 @@ Some scenarios require multiple applications or services to use the same NAT. In
 
 9. Net start docker  
    *Docker will use the user-defined NAT network as the default to connect Windows containers*  
- 
+
 In the end, you should have two internal vSwitches – one named DockerNAT and the other named nat. You will only have one NAT network (10.0.0.0/17) confirmed by running Get-NetNat. IP addresses for Windows containers will be assigned by the Windows Host Network Service (HNS) from the 10.0.76.0/24 subnet. Based on the existing MobyLinux.ps1 script, IP addresses for Docker 4 Windows will be assigned from the 10.0.75.0/24 subnet.
 
 

--- a/virtualization/windowscontainers/deployment/deployment_nano.md
+++ b/virtualization/windowscontainers/deployment/deployment_nano.md
@@ -177,7 +177,7 @@ Once completed the Docker daemon can be accessed with the `Docker -H` parameter.
 docker -H tcp://10.0.0.5:2376 run -it nanoserver cmd
 ```
 
-An environmental variable `DOCKER_HOST` can be created which will remove the `–H` parameter requirement. The following PowerShell command can be used for this.
+An environmental variable `DOCKER_HOST` can be created which will remove the `-H` parameter requirement. The following PowerShell command can be used for this.
 
 ```none
 $env:DOCKER_HOST = "tcp://<ipaddress of server:2376"

--- a/virtualization/windowscontainers/deployment/docker_windows.md
+++ b/virtualization/windowscontainers/deployment/docker_windows.md
@@ -223,10 +223,10 @@ To do so, ensure that the Docker daemon has been configured to listen on a TCP p
 To remotely deploy a container and enter an interactive session, run the following command.
 
 ```none
-docker –H tcp://<ipaddress of server>:2376 run –it nanoserver cmd
+docker -H tcp://<ipaddress of server>:2376 run -it nanoserver cmd
 ```
 
-An environmental variable DOCKER_HOST can be created that will remove the –H parameter requirement. The following PowerShell command can be used for this.
+An environmental variable DOCKER_HOST can be created that will remove the -H parameter requirement. The following PowerShell command can be used for this.
 
 ```none
 $env:DOCKER_HOST = "tcp://<ipaddress of server:2376"
@@ -235,7 +235,7 @@ $env:DOCKER_HOST = "tcp://<ipaddress of server:2376"
 With this variable set, the command would now look like this.
 
 ```none
-docker run –it nanoserver cmd
+docker run -it nanoserver cmd
 ```
 
 ### Removing Docker <!--2-->

--- a/virtualization/windowscontainers/quick_start/quick_start_windows_10.md
+++ b/virtualization/windowscontainers/quick_start/quick_start_windows_10.md
@@ -29,13 +29,13 @@ This quick start is specific to Hyper-V containers on Windows 10. Additional qui
 The container feature needs to be enabled before working with Windows containers. To do so run the following command in an elevated PowerShell session. 
 
 ```none
-Enable-WindowsOptionalFeature -Online -FeatureName containers –All
+Enable-WindowsOptionalFeature -Online -FeatureName containers -All
 ```
 
 Because Windows 10 only supports Hyper-V containers, the Hyper-V feature must also be enabled. To enable the Hyper-V feature using PowerShell, run the following command in an elevated PowerShell session.
 
 ```none
-Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V –All
+Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
 ```
 
 When the installation has completed, reboot the computer.

--- a/windows-container-samples/windowsservercore/golang/README.md
+++ b/windows-container-samples/windowsservercore/golang/README.md
@@ -2,7 +2,7 @@
 
 Creates an image containing golang 1.5.1.
 
-This dockerfile is for demonstration purposes and may require modification for production use. 
+This dockerfile is for demonstration purposes and may require modification for production use.
 
 # Environment:
 
@@ -16,12 +16,12 @@ Windows Server Core Base OS Image
 docker build -t golang:latest .
 ```
 
-**Docker Run** 
+**Docker Run**
 
-This will start a container, display the Go version, and then exit.  Modify the Dockerfile appropriately for application use. 
+This will start a container, display the Go version, and then exit.  Modify the Dockerfile appropriately for application use.
 
 ```
-docker run –it golang
+docker run -it golang
 ```
 
 ## Dockerfile Details:
@@ -39,5 +39,3 @@ RUN powershell -Command \
 
 RUN setx PATH %PATH%;c:\go\bin
 ```
-
-

--- a/windows-container-samples/windowsservercore/ruby/README.md
+++ b/windows-container-samples/windowsservercore/ruby/README.md
@@ -21,7 +21,7 @@ docker build -t ruby:latest .
 This will display the Ruby version and exit. Modify the Dockerfile appropriately for application use.
 
 ```
-docker run –it ruby
+docker run -it ruby
 ```
 
 ## Dockerfile Details:


### PR DESCRIPTION
Had some trouble copy-pasting commands in the Windows 10 page.

* Replace `–` with `-`
* Fix some quotes
* Atom has removed some trailing spaces
