### PR TITLE
(minor) Python sample fix CMD to pass arguments separately

### DIFF
--- a/windows-container-samples/windowsservercore/python/README.md
+++ b/windows-container-samples/windowsservercore/python/README.md
@@ -41,7 +41,7 @@ RUN powershell.exe -Command \
 
 RUN echo print("Hello World!") > c:\hello.py
 
-CMD ["py c:/hello.py"]
+CMD ["py", "c:/hello.py"]
 		
 ```
 

--- a/windows-container-samples/windowsservercore/python/dockerfile
+++ b/windows-container-samples/windowsservercore/python/dockerfile
@@ -13,4 +13,4 @@ RUN powershell.exe -Command \
 
 RUN echo print("Hello World!") > c:\hello.py
 
-CMD ["py c:/hello.py"]
+CMD ["py", "c:/hello.py"]


### PR DESCRIPTION
CMD ["py C:\hello.py"] results in an error "Command 'py C:\hello.py' no found".

Splitting it into separate arguments fixes the issue. 