### PR TITLE
Fix typo teak -> take

### DIFF
--- a/virtualization/windowscontainers/deployment/deployment.md
+++ b/virtualization/windowscontainers/deployment/deployment.md
@@ -13,13 +13,13 @@ ms.assetid: ba4eb594-0cdb-4148-81ac-a83b4bc337bc
 
 # Container Host Deployment - Windows Server
 
-**This is preliminary content and subject to change.** 
+**This is preliminary content and subject to change.**
 
 Deploying a Windows container host has different steps depending on the operating system and the host system type (physical or virtual). This document details deploying a Windows container host to either Windows Server 2016 or Windows Server Core 2016 on a physical or virtual system.
 
 ## Install Container Feature
 
-The container feature needs to be enabled before working with Windows containers. To do so run the following command in an elevated PowerShell session. 
+The container feature needs to be enabled before working with Windows containers. To do so run the following command in an elevated PowerShell session.
 
 ```none
 Install-WindowsFeature containers
@@ -72,16 +72,16 @@ Start-Service Docker
 ## Install Base Container Images
 
 Before a container can be deployed, a container base OS image needs to be downloaded. The following example will download the Windows Server Core base OS image. This same procedure can be completed to install the Nano Server base image. This same procedure can be completed to install the Nano Server base image. For detailed information on Windows container images, see [Managing Container Images](../management/manage_images.md).
-    
+
 First, install the container image package provider.
 
 ```none
 Install-PackageProvider ContainerImage -Force
 ```
 
-Next, install the Windows Server Core image. This process can take some time, so teak a break and pick back up once the download has completed.
+Next, install the Windows Server Core image. This process can take some time, so take a break and pick back up once the download has completed.
 
-```none 
+```none
 Install-ContainerImage -Name WindowsServerCore    
 ```
 
@@ -126,4 +126,3 @@ To enable the Hyper-V feature using PowerShell, run the following command in an 
 ```none
 Install-WindowsFeature hyper-v
 ```
-

--- a/virtualization/windowscontainers/quick_start/quick_start_windows_server.md
+++ b/virtualization/windowscontainers/quick_start/quick_start_windows_server.md
@@ -13,9 +13,9 @@ ms.assetid: e3b2a4dc-9082-4de3-9c95-5d516c03482b
 
 # Windows Containers on Windows Server
 
-**This is preliminary content and subject to change.** 
+**This is preliminary content and subject to change.**
 
-This exercise will walk through basic deployment and use of the Windows container feature on Windows Server. After completion, you will have installed the container role and have deployed a simple Windows Server container. Before starting this quick start, familiarize yourself with basic container concepts and terminology. This information can be found in the [Quick Start Introduction](./quick_start.md). 
+This exercise will walk through basic deployment and use of the Windows container feature on Windows Server. After completion, you will have installed the container role and have deployed a simple Windows Server container. Before starting this quick start, familiarize yourself with basic container concepts and terminology. This information can be found in the [Quick Start Introduction](./quick_start.md).
 
 This quick start is specific to Windows Server containers on Windows Server 2016. Additional quick start documentation can be found in the table of contents on the left hand side of this page.
 
@@ -25,7 +25,7 @@ This quick start is specific to Windows Server containers on Windows Server 2016
 
 ## 1. Install Container Feature
 
-The container feature needs to be enabled before working with Windows containers. To do so run the following command in an elevated PowerShell session. 
+The container feature needs to be enabled before working with Windows containers. To do so run the following command in an elevated PowerShell session.
 
 ```none
 Install-WindowsFeature containers
@@ -75,17 +75,17 @@ Start-Service Docker
 
 ## 3. Install Base Container Images
 
-Windows containers are deployed from templates or images. Before a container can be deployed, a base OS image needs to be downloaded. The following commands will download the Windows Server Core base image. 
-    
+Windows containers are deployed from templates or images. Before a container can be deployed, a base OS image needs to be downloaded. The following commands will download the Windows Server Core base image.
+
 First, install the container image package provider.
 
 ```none
 Install-PackageProvider ContainerImage -Force
 ```
 
-Next, install the Windows Server Core image. This process can take some time, so teak a break and pick back up once the download has completed.
+Next, install the Windows Server Core image. This process can take some time, so take a break and pick back up once the download has completed.
 
-```none 
+```none
 Install-ContainerImage -Name WindowsServerCore    
 ```
 


### PR DESCRIPTION
While working through https://msdn.microsoft.com/en-us/virtualization/windowscontainers/deployment/deployment to reproduce the issue in #296 I found a small typo.

`s/teak/take/g`
