### PR TITLE
Add -UseBasicParsing option to download commands

### DIFF
--- a/virtualization/windowscontainers/quick_start/quick_start_windows_server.md
+++ b/virtualization/windowscontainers/quick_start/quick_start_windows_server.md
@@ -50,13 +50,13 @@ New-Item -Type Directory -Path 'C:\Program Files\docker\'
 Download the Docker daemon.
 
 ```none
-Invoke-WebRequest https://aka.ms/tp5/b/dockerd -OutFile $env:ProgramFiles\docker\dockerd.exe
+Invoke-WebRequest https://aka.ms/tp5/b/dockerd -OutFile $env:ProgramFiles\docker\dockerd.exe -UseBasicParsing
 ```
 
 Download the Docker client.
 
 ```none
-Invoke-WebRequest https://aka.ms/tp5/b/docker -OutFile $env:ProgramFiles\docker\docker.exe
+Invoke-WebRequest https://aka.ms/tp5/b/docker -OutFile $env:ProgramFiles\docker\docker.exe -UseBasicParsing
 ```
 
 Add the Docker directory to the system path. When complete, restart the PowerShell session so that the modified path is recognized.


### PR DESCRIPTION
When following these instructions on a fresh installation of TP5, I encounter an error: "invoke-webrequest : The response content cannot be parsed because the Internet Explorer engine is not available..." Adding -UseBasicParsing avoids trying to use IE.