### PR TITLE
Remove single quotes in subject line

### DIFF
--- a/windows-server-container-tools/DockerTLS/DockerCertificateTools.ps1
+++ b/windows-server-container-tools/DockerTLS/DockerCertificateTools.ps1
@@ -236,7 +236,7 @@ Param(
 
     Write-Host "-Creating Server certificate request"
     #create certificate signing request
-    $subLine = ("/CN='" + $serverName + "'/")
+    $subLine = ("/CN=" + $serverName + "/")
 
     $openSSLCmd =  @("req", "-subj", $subLine, "-sha256", "-new", "-key", $serverKeyFile, "-out",  $serverCSRFile )
     Invoke-OpenSSLCmd -OpenSSLArguments $openSSLCmd


### PR DESCRIPTION
Wrapping the subject line in single quotes causes certificate authorization to fail.