### PR TITLE
Fix typo in script

### DIFF
--- a/virtualization/windowscontainers/management/container_networking.md
+++ b/virtualization/windowscontainers/management/container_networking.md
@@ -141,7 +141,7 @@ PS>	Stop-Service docker
 PS> Set-Service docker -StartupType Disabled
 Reboot Host
 PS> Get-NetNat | Remove-NetNat
-PS> Set-Service docker -StartupType automaticac
+PS> Set-Service docker -StartupType automatic
 PS> Start-Service docker 
 ```
 


### PR DESCRIPTION
Typo in script
I get:
```
PS C:\Windows\system32> Set-Service docker -StartupType automaticac
Set-Service : Cannot bind parameter 'StartupType'. Cannot convert value "automaticac"
to type "System.ServiceProcess.ServiceStartMode". Error: "Unable to match the
identifier name automaticac to a valid enumerator name. Specify one of the following
enumerator names and try again:
Boot, System, Automatic, Manual, Disabled"
At line:1 char:33
+ Set-Service docker -StartupType automaticac
+                                 ~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Set-Service], ParameterBindingExce
   ption
    + FullyQualifiedErrorId : CannotConvertArgumentNoMessage,Microsoft.PowerShell.Comm
   ands.SetServiceCommand
```