### PR TITLE
Change firewall rule to 2375 to match daemon TCP configuration

### DIFF
--- a/virtualization/windowscontainers/deployment/deployment_nano.md
+++ b/virtualization/windowscontainers/deployment/deployment_nano.md
@@ -151,7 +151,7 @@ For the best experience, and as a best practice, manage Docker on Nano Server fr
 Create a firewall rule on the container host for the Docker connection. This will be port `2375` for an unsecure connection, or port `2376` for a secure connection.
 
 ```none
-netsh advfirewall firewall add rule name="Docker daemon " dir=in action=allow protocol=TCP localport=2376
+netsh advfirewall firewall add rule name="Docker daemon " dir=in action=allow protocol=TCP localport=2375
 ```
 
 Configure the Docker daemon to accept incoming connection over TCP.


### PR DESCRIPTION
The example commands use 2375 for the firewall rule, but 2376 for the daemon configuration. This means example commands do not work beginning to end. Should be consistent, also suggest highlighting the fact that unsecure is used in the examples.