### PR TITLE
Update Install-ContainerHost.ps1 to latest NanoServer version

### DIFF
--- a/windows-server-container-tools/Install-ContainerHost/Install-ContainerHost.ps1
+++ b/windows-server-container-tools/Install-ContainerHost/Install-ContainerHost.ps1
@@ -419,8 +419,8 @@ Install-ContainerHost
                 if ($version -eq "14300")
                 {
                     $InstallParams.Add("MinimumVersion", "10.0.14300.1000")
-                    $InstallParams.Add("MaximumVersion", "10.0.14300.1010")
-                    $versionString = "-MinimumVersion 10.0.14300.1000 -MaximumVersion 10.0.14300.1010"
+                    $InstallParams.Add("MaximumVersion", "10.0.14300.1016")
+                    $versionString = "-MinimumVersion 10.0.14300.1000 -MaximumVersion 10.0.14300.1016"
                 }
                 else
                 {


### PR DESCRIPTION
This pull request updates Install-ContainerHost.ps1 to support the latest NanoServer image version (10.0.14300.1016). Because the version has changed on the SearchContainerImages.txt on http://go.microsoft.com/fwlink/?LinkID=746630&clcid=0x409 the scripts failed previously.