### PR TITLE
Fixing formatting around PowerShell snippet so you can copy & paste to run it

### DIFF
--- a/virtualization/windowscontainers/management/container_networking.md
+++ b/virtualization/windowscontainers/management/container_networking.md
@@ -142,7 +142,7 @@ Set-Service docker -StartupType Disabled
 ```
 > Reboot the host, then run the remaining steps:
 ```none
-Get-NetNat | Remove-NetNat
+Get-NetNat | Remove-NetNat -Confirm $false
 Set-Service docker -StartupType automatic
 Start-Service docker 
 ```

--- a/virtualization/windowscontainers/management/container_networking.md
+++ b/virtualization/windowscontainers/management/container_networking.md
@@ -136,7 +136,7 @@ foreach($key in $keys)
 }
 remove-netnat -Confirm:$false
 Get-ContainerNetwork | Remove-ContainerNetwork
-Get-VmSwitch -Name nat | Remove-VmSwitch (_failure is expected_)
+Get-VmSwitch -Name nat | Remove-VmSwitch # Note: failure is expected
 Stop-Service docker
 Set-Service docker -StartupType Disabled
 ```

--- a/virtualization/windowscontainers/management/container_networking.md
+++ b/virtualization/windowscontainers/management/container_networking.md
@@ -140,8 +140,7 @@ Get-VmSwitch -Name nat | Remove-VmSwitch (_failure is expected_)
 Stop-Service docker
 Set-Service docker -StartupType Disabled
 ```
-
-Reboot the host, then run the remaining steps:
+> Reboot the host, then run the remaining steps:
 ```none
 Get-NetNat | Remove-NetNat
 Set-Service docker -StartupType automatic

--- a/virtualization/windowscontainers/management/container_networking.md
+++ b/virtualization/windowscontainers/management/container_networking.md
@@ -124,25 +124,28 @@ New-ContainerNetwork -Name MyNatNetwork -Mode NAT -SubnetPrefix "172.16.0.0/12" 
 
 > There is a known bug in Windows Server 2016 Technical Preview 5 and recent Windows Insider Preview (WIP) "flighted" builds where, upon upgrade to a new build results in a duplicate (i.e. "leaked") container network and vSwitch. In order to work-around this issue, please run the following script.
 ```none
-PS> $KeyPath = "HKLM:\SYSTEM\CurrentControlSet\Services\vmsmp\parameters\SwitchList"
-PS> $keys = get-childitem $KeyPath
-PS> foreach($key in $keys)
-PS> {
-PS>    if ($key.GetValue("FriendlyName") -eq 'nat')
-PS>    {
-PS>       $newKeyPath = $KeyPath+"\"+$key.PSChildName
-PS>       Remove-Item -Path $newKeyPath -Recurse
-PS>    }
-PS> }
-PS> remove-netnat -Confirm:$false
-PS> Get-ContainerNetwork | Remove-ContainerNetwork
-PS>	Get-VmSwitch -Name nat | Remove-VmSwitch (_failure is expected_)
-PS>	Stop-Service docker
-PS> Set-Service docker -StartupType Disabled
-Reboot Host
-PS> Get-NetNat | Remove-NetNat
-PS> Set-Service docker -StartupType automatic
-PS> Start-Service docker 
+$KeyPath = "HKLM:\SYSTEM\CurrentControlSet\Services\vmsmp\parameters\SwitchList"
+$keys = get-childitem $KeyPath
+foreach($key in $keys)
+{
+   if ($key.GetValue("FriendlyName") -eq 'nat')
+   {
+      $newKeyPath = $KeyPath+"\"+$key.PSChildName
+      Remove-Item -Path $newKeyPath -Recurse
+   }
+}
+remove-netnat -Confirm:$false
+Get-ContainerNetwork | Remove-ContainerNetwork
+Get-VmSwitch -Name nat | Remove-VmSwitch (_failure is expected_)
+Stop-Service docker
+Set-Service docker -StartupType Disabled
+```
+
+Reboot the host, then run the remaining steps:
+```none
+Get-NetNat | Remove-NetNat
+Set-Service docker -StartupType automatic
+Start-Service docker 
 ```
 
 ### Transparent Networking


### PR DESCRIPTION
This workaround is still sometimes needed after builds are upgraded. I adjusted the formatting so that I could copy & paste it into a PowerShell window and have it run without errors.