### PR TITLE
Switching to new image with updated daemon and microsoft/nanoserver image

### DIFF
--- a/windows-server-container-tools/containers-azure-template/azuredeploy.json
+++ b/windows-server-container-tools/containers-azure-template/azuredeploy.json
@@ -45,6 +45,7 @@
     "windowsOSVersion": "2016-Technical-Preview-with-Containers",
     "imagePublisher": "MicrosoftWindowsServer",
     "imageOffer": "WindowsServer",
+    "imageVersion": "5.0.20160803",
     "OSDiskName": "[concat(parameters('VMName'),'_osdisk')]",
     "nicName": "[concat(parameters('VMName'),'_nic')]",
     "addressPrefix": "10.0.0.0/16",
@@ -234,7 +235,7 @@
             "publisher": "[variables('imagePublisher')]",
             "offer": "[variables('imageOffer')]",
             "sku": "[variables('windowsOSVersion')]",
-            "version": "latest"
+            "version": "[variables('imageVersion')]"
           },
           "osDisk": {
             "name": "osdisk",


### PR DESCRIPTION
There's an updated VHD that uses Docker v1.12, and has already run `docker pull Microsoft/windowsservercore`. We rebuilt all the images to use this version recently, and put an updated image on Azure. However, we didn't update the ARM template. This moves it to the known good version again.

This resolves #351 reported by @ddobric 

@taylorb-microsoft @enderb-ms do you want to give this a look before we merge it?