### PR TITLE
update apache-http Dockerfile to use most recent version and change to 64 bit

### DIFF
--- a/windows-container-samples/windowsservercore/apache-http/Dockerfile
+++ b/windows-container-samples/windowsservercore/apache-http/Dockerfile
@@ -3,19 +3,19 @@
 
 FROM windowsservercore
 
-LABEL Description="Apache" Vendor="Apache Software Foundation" Version="2.4.18"
+LABEL Description="Apache" Vendor="Apache Software Foundation" Version="2.4.23"
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-	Invoke-WebRequest -Method Get -Uri https://www.apachelounge.com/download/VC11/binaries/httpd-2.4.18-win32-VC11.zip -OutFile c:\apache.zip ; \
+	Invoke-WebRequest -Method Get -Uri https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.23-win64-VC14.zip -OutFile c:\apache.zip ; \
 	Expand-Archive -Path c:\apache.zip -DestinationPath c:\ ; \
 	Remove-Item c:\apache.zip -Force
 
 RUN powershell -Command \
 	$ErrorActionPreference = 'Stop'; \
-   	Invoke-WebRequest -Method Get -Uri "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe" -OutFile c:\vcredist_x86.exe ; \
-   	start-Process c:\vcredist_x86.exe -ArgumentList '/quiet' -Wait ; \
-   	Remove-Item c:\vcredist_x86.exe -Force
+	Invoke-WebRequest -Method Get -Uri "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe" -OutFile c:\vc_redist.x64.exe ; \
+	start-Process c:\vc_redist.x64.exe -ArgumentList '/quiet' -Wait ; \
+	Remove-Item c:\vc_redist.x64.exe -Force
 
 WORKDIR /Apache24/bin
 


### PR DESCRIPTION
The current 2.4.18 link is broken. Besides, there is no specific reason to run 32 bit.

https://social.msdn.microsoft.com/Forums/en-US/dd32304c-06ac-4ad2-9acb-518602c75249/github-container-example-for-apache-produces-nonzero-code-255-on-tp5?forum=windowscontainers