### PR TITLE
Change final docker run commands

### DIFF
--- a/virtualization/windowscontainers/deployment/deployment_nano.md
+++ b/virtualization/windowscontainers/deployment/deployment_nano.md
@@ -191,7 +191,7 @@ $env:path += ";c:\program files\docker"
 Once completed the remote Docker host can be accessed with the `docker -H` parameter.
 
 ```none
-docker -H tcp://<IPADDRESS>:2375 run -it nanoserver cmd
+docker -H tcp://<IPADDRESS>:2375 run -it microsoft/nanoserver cmd
 ```
 
 An environmental variable `DOCKER_HOST` can be created which will remove the `-H` parameter requirement. The following PowerShell command can be used for this.
@@ -203,7 +203,7 @@ $env:DOCKER_HOST = "tcp://<ipaddress of server>:2375"
 With this variable set, the command would now look like this.
 
 ```none
-docker run -it nanoserver cmd
+docker run -it microsoft/nanoserver cmd
 ```
 
 ## Hyper-V Container Host


### PR DESCRIPTION
The final "docker ... run" commands on line 194 and 206 needs to start from the "microsoft/nanoserver" image, not "nanoserver". This is to be consistent with the rest of the article...