### PR TITLE
Fixing KB detection logic, suppressing error if no eventlogs found

### DIFF
--- a/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
+++ b/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
@@ -16,4 +16,4 @@ $levels = 3,2,1,0
 $providers = "Docker", "Microsoft-Windows-Hyper-V-Compute"
 
 # Get-EventLog -LogName Application -Source Docker -After $logStartTime -EntryType Warning, Error | Format-List TimeGenerated, Message
-Get-WinEvent -FilterHashtable @{Logname=$logNames; StartTime=$logStartTime; Level=$levels; ProviderName=$providers}
+Get-WinEvent -FilterHashtable @{Logname=$logNames; StartTime=$logStartTime; Level=$levels; ProviderName=$providers} -ErrorAction Ignore

--- a/windows-server-container-tools/Debug-ContainerHost/Windows.Tests.ps1
+++ b/windows-server-container-tools/Debug-ContainerHost/Windows.Tests.ps1
@@ -3,10 +3,10 @@ Describe "Windows Version and Prerequisites" {
     It "Is Windows 10 Anniversary Update or Windows Server 2016" {
         $buildNumber -ge 14393 | Should Be $true
     }
-    It "Has KB3192366 and/or KB3194496 installed if running Windows build 14393" {
+    It "Has KB3192366, KB3194496, or later installed if running Windows build 14393" {
         if ($buildNumber -eq 14393)
         {
-            Get-CimInstance -n root\cimv2 -Query "SELECT * FROM Win32_QuickFixEngineering WHERE HotFixID = 'KB3192366' OR HotFixId = 'KB3194496'" | Should Not Be $null
+            (Get-ItemProperty -Path 'HKLM:\software\Microsoft\Windows NT\CurrentVersion' -Name UBR).UBR | Should Not BeLessThan 206
         }
     }
     It "Is not a build with blocking issues" {


### PR DESCRIPTION
Fixing a bug in the installed KB detection logic. The update rollup number will be incrementing in the registry, so it's easier to check that instead of a list of specific KBs.

This also suppresses an error if no error/warning event logs are found :)