### PR TITLE
Updating OpenSSL download link.

### DIFF
--- a/windows-server-container-tools/DockerTLS/DockerCertificateTools.ps1
+++ b/windows-server-container-tools/DockerTLS/DockerCertificateTools.ps1
@@ -100,7 +100,7 @@ Param(
 #>
 function Install-OpenSSL {
 Param(
-  [String] $OpenSSLDownloadPath = "https://slproweb.com/download/Win64OpenSSL_Light-1_0_2h.exe",
+  [String] $OpenSSLDownloadPath = "https://slproweb.com/download/Win64OpenSSL_Light-1_0_2j.exe",
   [String] $DownloadLocation = $env:TEMP,
   [String] $InstallLocation = $Global:PathToOpenSSL.Replace("bin\openssl.exe", "")
   )


### PR DESCRIPTION
The "2h" version is no longer available and that link leads to a 404.  Switching to the "2j" version works.