### PR TITLE
Adding docker version info and error CSV file

### DIFF
--- a/windows-server-container-tools/Debug-ContainerHost/README.md
+++ b/windows-server-container-tools/Debug-ContainerHost/README.md
@@ -122,7 +122,6 @@ These registry values should not be needed, and can be removed. Some past test b
 
 ## Contributing to Debug-ContainerHost.ps1
 Contributions are welcome! Here are a few suggested areas needing improvement:
-- Include `docker info` and `docker version` output
 - Add options to start & stop log collections to Debug-ContainerHost.ps1, create CSV file
 - Add a commitId and date to script output so it's easier to troubleshoot the troubleshooting script
 - Search for TODO in *.ps1 for incomplete tests


### PR DESCRIPTION
This adds some new script output and also saves the warning & error logs to a CSV file. 

Here's examples of the new output:
```none
Showing output from: docker version
Client:
 Version:      1.13.0-dev
 API version:  1.25
 Go version:   go1.7.1
 Git commit:   cd0e399
 Built:        Mon Oct 17 22:42:06 2016
 OS/Arch:      windows/amd64

Server:
 Version:      1.13.0-dev
 API version:  1.25
 Go version:   go1.7.1
 Git commit:   cd0e399
 Built:        Mon Oct 17 22:42:06 2016
 OS/Arch:      windows/amd64

Showing output from: docker info
Containers: 13
 Running: 0
 Paused: 0
 Stopped: 13
Images: 17
Server Version: 1.13.0-dev
Storage Driver: windowsfilter
 Windows:
Logging Driver: json-file
Plugins:
 Volume: local
 Network: nat null overlay
Swarm: inactive
Default Isolation: hyperv
Kernel Version: 10.0 14393 (14393.321.amd64fre.rs1_release_inmarket.161004-2338)
Operating System: Windows 10 Enterprise
OSType: windows
Architecture: x86_64
CPUs: 4
Total Memory: 7.899 GiB
Name: plangy
ID: 
Docker Root Dir: C:\ProgramData\docker
Debug Mode (client): false
Debug Mode (server): true
 File Descriptors: -1
 Goroutines: 27
 System Time: 2016-10-19T10:41:59.9775304-07:00
 EventsListeners: 0
Registry: https://index.docker.io/v1/
Insecure Registries:
 127.0.0.0/8
Live Restore Enabled: false

...

Logs saved to C:\Users\user\Source\Virtualization-Documentation\windows-server-container-tools\Debug-ContainerHost\logs_20161019-104202.csv
```