### PR TITLE
Docker service fails to start if the ProgramData\docker directory does not exist.

### DIFF
--- a/virtualization/windowscontainers/quick_start/quick_start_windows_10.md
+++ b/virtualization/windowscontainers/quick_start/quick_start_windows_10.md
@@ -64,6 +64,12 @@ Expand the zip archive into Program Files, the archive contents is already in do
 Expand-Archive -Path "$env:TEMP\docker-1.13.0-dev.zip" -DestinationPath $env:ProgramFiles
 ```
 
+Create data directory for Docker.
+
+```none
+New-Item -ItemType Directory -Force -Path "$env:ProgramData\docker"
+```
+
 Add the Docker directory to the system path.
 
 ```none


### PR DESCRIPTION
Added powershell command to create the directory in the documentation.