### PR TITLE
check for existing service corrected

### DIFF
--- a/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
+++ b/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
@@ -24,7 +24,7 @@ Describe "Docker is installed" {
     
     $service = Get-Service | Where-Object {($_.Name -eq "Docker") -or ($_.Name -eq "com.Docker.Service")}
     It "A Docker service is installed - 'Docker' or 'com.Docker.Service' " {
-        $service | Should Not Be Null
+        $service | Should Not BeNullorEmpty
     }
     It "Service is running" {
         $service.Status | Should Be Running


### PR DESCRIPTION
"Should Not Be Null" always returns "ok" even if $service -eq $null


tested it
```
 $service = Get-Service | Where-Object {($_.Name -eq "Docker") -or ($_.Name -eq "com.Docker.Service")}
    It "A Docker service is installed - 'Docker' or 'com.Docker.Service' " {
        write-warning " is not null: $($service -ne $null)"
        # $service | Should Not BeNullorEmpty
        $service | Should Not Be Null
```

obviously "Null" is unknown to pester?