### PR TITLE
Update minimum working build for the Debug script

### DIFF
--- a/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
+++ b/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
@@ -10,7 +10,7 @@ Describe "Windows Version and Prerequisites" {
     It "Has KB3192366, KB3194496, or later installed if running Windows build 14393" {
         if ($buildNumber -eq 14393)
         {
-            (Get-ItemProperty -Path 'HKLM:\software\Microsoft\Windows NT\CurrentVersion' -Name UBR).UBR | Should Not BeLessThan 206
+            (Get-ItemProperty -Path 'HKLM:\software\Microsoft\Windows NT\CurrentVersion' -Name UBR).UBR | Should Not BeLessThan 351
         }
     }
     It "Is not a build with blocking issues" {


### PR DESCRIPTION
It seems we need 351 as latest build for proper working Docker

See https://github.com/docker/for-win/issues/169