### PR TITLE
Changed in the sample Dockerfile

### DIFF
--- a/virtualization/windowscontainers/docker/manage_windows_dockerfile.md
+++ b/virtualization/windowscontainers/docker/manage_windows_dockerfile.md
@@ -39,7 +39,7 @@ In its most basic form, a Dockerfile can be very simple. The following example c
 # Sample Dockerfile
 
 # Indicates that the windowsservercore image will be used as the base image.
-FROM windowsservercore
+FROM microsoft/windowsservercore
 
 # Metadata indicating an image maintainer.
 MAINTAINER jshelton@contoso.com


### PR DESCRIPTION
I've noticed that in the sample Dockerfile has beend used the notation FROM windowsservercore this in a local build will result in an error due the fact that the local latest images is named microsoft/windowsservercore