### PR TITLE
Fixed the Docker Service check when more docker services are running

### DIFF
--- a/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
+++ b/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
@@ -24,13 +24,19 @@ Describe "Docker is installed" {
     
     $services = Get-Service | Where-Object {($_.Name -eq "Docker") -or ($_.Name -eq "com.Docker.Service")}
     It "A Docker service is installed - 'Docker' or 'com.Docker.Service' " {
-        $services | Should Not BeNullOrEmpty
+        $services| Should Not BeNullOrEmpty
     }
     It "Service is running" {
+        $AtLeastOneRunning = $false;
         foreach ($service in $services)
         {
-           $service.Status | Should Be Running
+           #if there is more than 1 only one can be running
+           if ($service.Status -eq "Running")
+           {
+                $AtLeastOneRunning = $true
+           }
         }        
+        $AtLeastOneRunning | Should Be $true
     }
     It "Docker.exe is in path" {
         # This also captures 'docker info' and 'docker version' output to be shown later


### PR DESCRIPTION
When both Linux and Windows Docker are running, you get an error because one of the services is stopped. Succeeding test if 1 of the 2 services is running