### PR TITLE
Proposal: Add microsoft/msbuild image

### DIFF
--- a/windows-container-samples/vcbuildtools/Dockerfile
+++ b/windows-container-samples/vcbuildtools/Dockerfile
@@ -1,0 +1,19 @@
+FROM microsoft/windowsservercore
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest 'http://download.microsoft.com/download/5/f/7/5f7acaeb-8363-451f-9425-68a90f98b238/visualcppbuildtools_full.exe' -OutFile 'visualcppbuildtools_full.exe' -UseBasicParsing ; \
+    Start-Process .\visualcppbuildtools_full.exe -ArgumentList '/NoRestart /S' -Wait ; \
+    Remove-Item visualcppbuildtools_full.exe
+
+RUN Write-Host 'Configuring environment'; \
+	pushd 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC' ; \
+	cmd /c 'vcvarsall.bat amd64&set' | foreach { \
+    if ($_ -match '=') { \
+      $v = $_.split('='); \
+      [Environment]::SetEnvironmentVariable($v[0], $v[1], [EnvironmentVariableTarget]::Machine); \
+    } \
+  } ; \
+	popd
+
+WORKDIR /code

--- a/windows-container-samples/vcbuildtools/README.md
+++ b/windows-container-samples/vcbuildtools/README.md
@@ -1,0 +1,15 @@
+# vcbuildtools
+
+Build a Docker image with Visual C++ Build tools.
+
+## Build image
+
+```
+docker build -t vcbuildtools:14.3 .
+```
+
+## Use the image
+
+```
+docker run -v "$(pwd):C:\code" vcbuildtools:14.3 msbuild yourproject.sln /p:Configuration=Release
+```


### PR DESCRIPTION
Here is a `Dockerfile` to build a Docker image with the Visual Studio C++ Build tools installed.
It would be great if we have something like `FROM microsoft/vcbuildtools:14.3` to run `msbuild` in a Container very easily.

How to use this image

## Build the image

```
docker build -t microsoft/vcbuildtools:14.3 .
```

## Use the image

Go into a folder with a simple C++ or other project with a solution file *.sln.

```
docker run -v "$(pwd):C:\code" microsoft/vcbuildtools:14.3 msbuild yourproject.sln /p:Configuration=Release
```

Example:

```
git clone https://github.com/StefanScherer/win-getaddrinfo
cd win-getaddrinfo
docker run -v "$(pwd):C:\code" microsoft/vcbuildtools:14.3 msbuild getaddrinfo.sln /p:Configuration=Release
dir getaddrinfo.exe
```

