### PR TITLE
Use Get-ADDomain instead of Get-Domain

### DIFF
--- a/windows-server-container-tools/ServiceAccounts/README.md
+++ b/windows-server-container-tools/ServiceAccounts/README.md
@@ -124,7 +124,7 @@ In addition to the default account that will be mapped to 'Local System' and 'Ne
 Here's an example where two additional accounts - 'LogApp' and 'AuditApp' are added:
 
 ```powershell
-New-CredentialSpec –Name "App2" –Domain (Get-Domain) –AccountName "ProductionApp" –AdditionalAccounts @{DomainName="domain.contoso.com";AccountName="LogApp"}, @{DomainName="domain.contoso.com";AccountName="AuditApp"}
+New-CredentialSpec –Name "App2" –Domain (Get-ADDomain) –AccountName "ProductionApp" –AdditionalAccounts @{DomainName="domain.contoso.com";AccountName="LogApp"}, @{DomainName="domain.contoso.com";AccountName="AuditApp"}
 ```
 
 A scheduled task or service can now be configured to use these accounts.


### PR DESCRIPTION
When calling the New-CredentialSpec cmdlet the domain should set with the Get-ADDomain.
See CredentialSpec.psm1 for implementation details and examples.