### PR TITLE
Change Docker from v1.14 to v1.13-rc2

### DIFF
--- a/virtualization/windowscontainers/quick_start/quick_start_windows_10.md
+++ b/virtualization/windowscontainers/quick_start/quick_start_windows_10.md
@@ -56,13 +56,13 @@ Docker is required in order to work with Windows containers. Docker consists of 
 Download the Docker engine and client as a zip archive.
 
 ```none
-Invoke-WebRequest "https://master.dockerproject.org/windows/amd64/docker-1.14.0-dev.zip" -OutFile "$env:TEMP\docker-1.14.0-dev.zip" -UseBasicParsing
+Invoke-WebRequest "https://test.docker.com/builds/Windows/x86_64/docker-1.13.0-rc2.zip" -OutFile "$env:TEMP\docker-1.13.0-rc2.zip" -UseBasicParsing
 ```
 
 Expand the zip archive into Program Files, the archive contents is already in docker directory.
 
 ```none
-Expand-Archive -Path "$env:TEMP\docker-1.14.0-dev.zip" -DestinationPath $env:ProgramFiles
+Expand-Archive -Path "$env:TEMP\docker-1.13.0-rc2.zip" -DestinationPath $env:ProgramFiles
 ```
 
 Add the Docker directory to the system path.


### PR DESCRIPTION
I suggested we move to the Docker v1.13 rc builds in #488, but #496 was merged instead. We should be using v1.13-rc as it's the most stable right now.

I'm testing this on another system and will merge it shortly