### PR TITLE
Speed up 'Has Containers feature installed' test

### DIFF
--- a/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
+++ b/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
@@ -19,7 +19,7 @@ Describe "Windows Version and Prerequisites" {
     }
 
     It "Has 'Containers' feature installed" {
-        if (((Get-ComputerInfo).OsProductType) -eq "Workstation") {
+        if ((Get-Command Get-WindowsFeature -ErrorAction Ignore) -eq $null ) {
             (Get-WindowsOptionalFeature -Online -FeatureName Containers).State | Should Be "Enabled"
         }
         else {

--- a/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
+++ b/windows-server-container-tools/Debug-ContainerHost/Debug-ContainerHost.ps1
@@ -19,7 +19,7 @@ Describe "Windows Version and Prerequisites" {
     }
 
     It "Has 'Containers' feature installed" {
-        if ((Get-Command Get-WindowsFeature -ErrorAction Ignore) -eq $null ) {
+        if ((Get-Command Get-WindowsFeature -ErrorAction Ignore) -eq $null) {
             (Get-WindowsOptionalFeature -Online -FeatureName Containers).State | Should Be "Enabled"
         }
         else {


### PR DESCRIPTION
`Get-ComputerInfo` is a slow way to determine whether you're on Windows 10 or Windows Server 2016. The only reason I was calling it was to decide which PowerShell cmdlet to use to check if the `Containers` role was installed. Checking if the cmdlet exists is much faster!