### PR TITLE
Update azuredeploy imageVersion 2016.0.20170127

### DIFF
--- a/windows-server-container-tools/containers-azure-template/azuredeploy.json
+++ b/windows-server-container-tools/containers-azure-template/azuredeploy.json
@@ -45,7 +45,7 @@
     "imageSku": "2016-Datacenter-with-Containers",
     "imagePublisher": "MicrosoftWindowsServer",
     "imageOffer": "WindowsServer",
-    "imageVersion": "2016.0.20161012",
+    "imageVersion": "2016.0.20170127",
     "OSDiskName": "[concat(parameters('VMName'),'_osdisk')]",
     "nicName": "[concat(parameters('VMName'),'_nic')]",
     "addressPrefix": "10.0.0.0/16",
@@ -255,7 +255,7 @@
         }
       },
       "resources": [
-        
+
       ]
     }
   ]


### PR DESCRIPTION
I used the "Deploy to Azure" button at https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/quick-start-windows-server but found out that it only spins up a Windows Server 2016 with old Docker images rev 321

Now pulling microsoft/iis downloads the rev 693 windowsservercore base image, but that takes a long time.
