### PR TITLE
Use live branch for azuredeploy

### DIFF
--- a/virtualization/windowscontainers/quick-start/quick-start-windows-server.md
+++ b/virtualization/windowscontainers/quick-start/quick-start-windows-server.md
@@ -23,7 +23,7 @@ One computer system (physical or virtual) running Windows Server 2016. If you ar
 > Critical updates are needed in order for the Windows Container feature to function. Please install all updates before working through this tutorial.
 
 If you would like to deploy on Azure, this [template](https://github.com/Microsoft/Virtualization-Documentation/tree/master/windows-server-container-tools/containers-azure-template) makes it easy.<br/>
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FVirtualization-Documentation%2Fmaster%2Fwindows-server-container-tools%2Fcontainers-azure-template%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FVirtualization-Documentation%2Flive%2Fwindows-server-container-tools%2Fcontainers-azure-template%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/windows-server-container-tools/containers-azure-template/README.md
+++ b/windows-server-container-tools/containers-azure-template/README.md
@@ -2,10 +2,10 @@
 
 This template will deploy a Windows Server 2016 virtual machine with the Windows container feature, and Docker, fully installed and configured.
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FVirtualization-Documentation%2Fmaster%2Fwindows-server-container-tools%2Fcontainers-azure-template%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FVirtualization-Documentation%2Flive%2Fwindows-server-container-tools%2Fcontainers-azure-template%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
-<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FVirtualization-Documentation%2Fmaster%2Fwindows-server-container-tools%2Fcontainers-azure-template%2Fazuredeploy.json" target="_blank">
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FMicrosoft%2FVirtualization-Documentation%2Flive%2Fwindows-server-container-tools%2Fcontainers-azure-template%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 

--- a/windows-server-container-tools/containers-azure-template/azuredeploy.json
+++ b/windows-server-container-tools/containers-azure-template/azuredeploy.json
@@ -86,6 +86,21 @@
           },
 
           {
+            "name": "HTTPS",
+            "properties": {
+              "description": "HTTPS",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          },
+
+          {
             "name": "RDP",
             "properties": {
               "description": "RDP",

--- a/windows-server-container-tools/containers-azure-template/metadata.json
+++ b/windows-server-container-tools/containers-azure-template/metadata.json
@@ -1,7 +1,7 @@
 {
-  "itemDisplayName": "Windows Server Container Preview Host",
-  "description": "This template will create a Windows Server 2016 TP5 with Windows Server Containers.",
-  "summary": "Provision a Docker ready Windows Server Container Preview Host",
+  "itemDisplayName": "Windows Server Container Host",
+  "description": "This template will create a Windows Server 2016 with Windows Server Containers.",
+  "summary": "Provision a Docker ready Windows Server Container Host",
   "githubUsername": "neilpeterson",
-  "dateUpdated": "2016-06-27"
+  "dateUpdated": "2017-02-28"
 }


### PR DESCRIPTION
Testing the "Deploy to Azure" button in https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/quick-start-windows-server after PR #569 got merged, I found out that the azuredeploy.json taken is from master branch.
I have changed the links to use live branch instead.
I also have updated the description in the template.
And I have added a security rule for HTTPS port 443, might be useful in addition to HTTP port 80.
