### PR TITLE
Fixing ERROR: client version 1.2x is too old. Minimum supported API version is 1.2x

### DIFF
--- a/windows-container-samples/ASP-NET-Blog-Application/docker-compose.yml
+++ b/windows-container-samples/ASP-NET-Blog-Application/docker-compose.yml
@@ -1,4 +1,4 @@
-﻿version: '2'
+﻿version: '2.1'
 
 services:
  web:


### PR DESCRIPTION
As https://github.com/docker/compose/issues/4106 states, the change to '2.1' fixes the following error, when running 'docker-compose up': ERROR: client version 1.2x is too old. Minimum supported API version is 1.2x, please upgrade your client to a newer version