### PR TITLE
removing ms.service metadata field

### DIFF
--- a/virtualization/windowscontainers/deploy-containers/system-requirements.md
+++ b/virtualization/windowscontainers/deploy-containers/system-requirements.md
@@ -6,7 +6,6 @@ author: enderb-ms
 ms.date: 09/26/2016
 ms.topic: deployment-article
 ms.prod: windows-containers
-ms.service: windows-containers
 ms.assetid: 3c3d4c69-503d-40e8-973b-ecc4e1f523ed
 ---
 


### PR DESCRIPTION
Please read the latest metadata guidelines, I believe that ms.assetID is also no longer needed :) https://review.docs.microsoft.com/en-us/help/contribute/contribute-how-to-write-metadata?branch=master