### PR TITLE
Fix typo on the dump directory for daemon

### DIFF
--- a/virtualization/windowscontainers/troubleshooting.md
+++ b/virtualization/windowscontainers/troubleshooting.md
@@ -99,7 +99,7 @@ Get-Process dockerd
 docker-signal -pid=<id>
 ```
 
-The output files will be located in the root directory docker is running in. The default directory is `C:\Program Files\Docker`. The actual directory can be confirmed by running `docker info -f "{{.DockerRootDir}}"`.
+The output files will be located in the data-root directory docker is running in. The default directory is `C:\ProgramData\Docker`. The actual directory can be confirmed by running `docker info -f "{{.DockerRootDir}}"`.
 
 The files will be `goroutine-stacks-<timestamp>.log` and `daemon-data-<timestamp>.log`.
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

I added the wrong directory for the location of the stack dumps. Fixed :dog: