### PR TITLE
Update broken link for SSL installation

### DIFF
--- a/windows-server-container-tools/DockerTLS/DockerCertificateTools.ps1
+++ b/windows-server-container-tools/DockerTLS/DockerCertificateTools.ps1
@@ -100,7 +100,7 @@ Param(
 #>
 function Install-OpenSSL {
 Param(
-  [String] $OpenSSLDownloadPath = "https://slproweb.com/download/Win64OpenSSL_Light-1_0_2j.exe",
+  [String] $OpenSSLDownloadPath = "https://slproweb.com/download/Win64OpenSSL_Light-1_0_2L.exe",
   [String] $DownloadLocation = $env:TEMP,
   [String] $InstallLocation = $Global:PathToOpenSSL.Replace("bin\openssl.exe", "")
   )
@@ -118,8 +118,8 @@ Param(
     if ($Continue)
     {
         New-Item -Path $InstallLocation -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
-        wget -uri $OpenSSLDownloadPath -OutFile ($DownloadLocation + "Win64OpenSSL_Light-1_0_2h.exe")
-        Start-Process -FilePath ($DownloadLocation + "Win64OpenSSL_Light-1_0_2h.exe") -ArgumentList @("/VERYSILENT", ("/DIR=`"" + $InstallLocation + "`"")) -Wait
+        wget -uri $OpenSSLDownloadPath -OutFile ($DownloadLocation + "Win64OpenSSL_Light-1_0_2L.exe")
+        Start-Process -FilePath ($DownloadLocation + "Win64OpenSSL_Light-1_0_2L.exe") -ArgumentList @("/VERYSILENT", ("/DIR=`"" + $InstallLocation + "`"")) -Wait
     }
 }
 


### PR DESCRIPTION
I notice that the link for install SSL is broken, so I replace the broken URL for one on the same provider that is working. Thanks!