### PR TITLE
Update ProcessorMask field size in HvCallSendSyntheticClusterIpi

### DIFF
--- a/virtualization/hyper-v-on-windows/tlfs/hypercalls/HvCallSendSyntheticClusterIpi.md
+++ b/virtualization/hyper-v-on-windows/tlfs/hypercalls/HvCallSendSyntheticClusterIpi.md
@@ -33,4 +33,4 @@ HvCallSendSyntheticClusterIpi(
 | `Vector`                | 0          | 4        | Specified the vector asserted. Must be between >= 0x10 and <= 0xFF.  |
 | `TargetVtl`             | 4          | 1        | Target VTL                                |
 | Padding                 | 5          | 3        |                                           |
-| `ProcessorMask`         | 8          | 1        | Specifies a mask representing VPs to target|
+| `ProcessorMask`         | 8          | 8        | Specifies a mask representing VPs to target|


### PR DESCRIPTION
This pull request makes a small correction to the documentation for the `HvCallSendSyntheticClusterIpi` hypercall. The change updates the size of the `ProcessorMask` field to accurately reflect its intended width.

Documentation correction:

* Updated the `ProcessorMask` field size from 1 byte to 8 bytes in the `HvCallSendSyntheticClusterIpi` documentation to accurately describe the mask representing VPs to target.